### PR TITLE
Dev

### DIFF
--- a/fooof/fooof.py
+++ b/fooof/fooof.py
@@ -24,9 +24,11 @@ class FOOOF(object):
     bandwidth_limits : tuple of (float, float)
         Setting to exclude gaussian fits where the bandwidth is implausibly narrow or wide
     max_n_oscs : int
-        XX
+        Maximum number of oscillations to be extracted in a single PSD.
     min_amp : float
-        XX
+        Minimum amplitude threshold for an oscillation to be extracted.
+    amp_std_thresh : float
+        Amplitude threshold for detecting oscillatory peaks, units of standard deviation.
 
     Attributes
     ----------
@@ -60,9 +62,7 @@ class FOOOF(object):
         Noise threshold for slope fitting.
     _sl_param_bounds :
         Parameter bounds for background fitting.
-    _amp_std_thresh : float
-        Amplitude threshold for detecting oscillatory peaks, units of standard deviation.
-    _bw_std_thresh : float
+    _bw_std_edge : float
         Banwidth threshold for edge rejection of oscillations, units of standard deviation.
     _std_limits : list of [float, float]
         Bandwidth limits, converted to use for gaussian standard deviation parameter.
@@ -76,13 +76,14 @@ class FOOOF(object):
         get smoother PSD's that will offer better FOOOF fits.
     """
 
-    def __init__(self, bandwidth_limits=(0.5, 12.0), max_n_oscs=np.inf, min_amp=0):
+    def __init__(self, bandwidth_limits=(0.5, 12.0), max_n_oscs=np.inf, min_amp=0.0, amp_std_thresh=2.0):
         """Initialize FOOOF object with run parameters."""
 
         # Set input parameters
         self.bandwidth_limits = bandwidth_limits
         self.max_n_oscs = max_n_oscs
         self.min_amp = min_amp
+        self.amp_std_thresh = amp_std_thresh
 
         ## SETTINGS
         # Noise threshold, as a percentage of the data.
@@ -90,10 +91,8 @@ class FOOOF(object):
         self._sl_amp_thresh = 0.025
         # Default 1/f parameter bounds. This limits slope to be less than 2 and no steeper than -8.
         self._sl_param_bounds = (-np.inf, -8, 0), (np.inf, 2, np.inf)
-        # St. deviation threshold, above residuals, to consider a peak an oscillation
-        self._amp_std_thresh = 2.5
         # Threshold for how far (in units of std. dev) an oscillation has to be from edge to keep
-        self._bw_std_thresh = 1.
+        self._bw_std_edge = 1.
 
         ## INTERAL PARAMETERS
         # Bandwidth limits are given in 2-sided oscillation bandwidth
@@ -170,7 +169,6 @@ class FOOOF(object):
         self.freq_range = freq_range
         self.freqs, self.psd = trim_psd(freqs, psd, self.freq_range)
 
-        # TEST - NEW
         # Check bandwidth limits against frequency resolution, warn if too close
         if round(self.freq_res, 1) >= self.bandwidth_limits[0]:
             print('\nFOOOF WARNING: Lower-bound Bandwidth limit is ~= the frequency resolution. \n', \
@@ -180,10 +178,7 @@ class FOOOF(object):
         self._background_fit, self.background_params = self._clean_background_fit(self.freqs, self.psd)
 
         # Flatten the PSD using fit background
-        psd_flat = self.psd - self._background_fit
-        # TEST - NOTE: Still drop below zero points?
-        #psd_flat[psd_flat < 0] = 0
-        self._psd_flat = psd_flat
+        self._psd_flat = self.psd - self._background_fit
 
         # Find oscillations, and fit them with gaussians
         self._gaussian_params = self._fit_oscs(np.copy(self._psd_flat))
@@ -338,7 +333,6 @@ class FOOOF(object):
             Values of fit slope.
         background_params : 1d array
             Parameters of slope fit (length of 3: offset, slope, curvature).
-
         """
 
         # Do a quick, initial slope fit
@@ -385,14 +379,10 @@ class FOOOF(object):
         # Initialize matrix of guess parameters for gaussian fitting
         guess = np.empty([0, 3])
 
-        # TEST: single estimate of amplitude std
-        #test_amp = self._amp_std_thresh * np.std(flat_iter)
-
-        # Find oscillations: loop through, checking residuals, stoppind based on STD check
-        #  NOTE: depending how good our osc_gauss guesses are, we are 'inducing' residuals
+        # Find oscillations: loop through, checking residuals, stopping based on STD check
+        #  NOTE: depending how good our osc_gauss guesses are, it can 'inducing' residuals
         #   As in - making negative error.
         #     So - with a bad fit, we could add a lot of error, increased STD, and make us stop early
-        #       Possibly: stop based on initial STD of flat (unsubtracted) PSD, not an iterative update PSD?
         #   Also: with low variance (no / small 'real' oscillation) this procedure is perhaps overzealous
         #       It finds and fits what we may want to consider small bumps.
         #           Perhaps play with STD val, or add an absolute threshold as well
@@ -402,27 +392,16 @@ class FOOOF(object):
             max_ind = np.argmax(flat_iter)
             max_amp = flat_iter[max_ind]
 
-            # TEST
-            #print('STD: ', np.std(flat_iter))
-            #print('VAR: ', np.var(flat_iter))
-            #plt.figure()
-            #plt.plot(flat_iter, '.')
-
             # Stop searching for oscillations peaks once drops below amplitude threshold
-            if max_amp <= self._amp_std_thresh * np.std(flat_iter):
+            if max_amp <= self.amp_std_thresh * np.std(flat_iter):
                break
-
-            # TEST:
-            #if max_amp <= test_amp:
-            #    break
 
             # Set the guess parameters for gaussian fitting - CF & Amp
             guess_freq = self.freqs[max_ind]
             guess_amp = max_amp
 
-            # TEST
+            # Halt fitting process is candidate osc drops below minimum amp size
             if not guess_amp > self.min_amp:
-                print('AMP BREAK')
                 break
 
             # Data driven guess BW
@@ -449,9 +428,6 @@ class FOOOF(object):
             #  Note: without this, curve_fitting fails if given guess > or < bounds
             if guess_std < self._std_limits[0]:
                 guess_std = self._std_limits[0]
-                # TEST
-                #print('BW Break!')
-                #break
             if guess_std > self._std_limits[1]:
                 guess_std = self._std_limits[1]
 
@@ -461,10 +437,6 @@ class FOOOF(object):
             # Subtract best-guess gaussian
             osc_gauss = gaussian_function(self.freqs, guess_freq, guess_amp, guess_std)
             flat_iter = flat_iter - osc_gauss
-
-        # TEST:
-        print('GUESS')
-        print(guess)
 
         # Check oscillation based on edges
         keep_osc = self._drop_osc_cf(guess)
@@ -490,8 +462,8 @@ class FOOOF(object):
 
         Returns
         -------
-        _gaussian_params : 2d array
-            Guess parameters for gaussian fits to oscillations. [n_oscs, 3], row: [CF, AMP, BW].
+        gaussian_params : 2d array
+            Parameters for gaussian fits to oscillations. [n_oscs, 3], row: [CF, AMP, BW].
         """
 
         # Set the bounds, +/- 1 BW for center frequency, positive amp value, & gauss limits
@@ -505,13 +477,13 @@ class FOOOF(object):
         guess = np.ndarray.flatten(guess)
 
         # Fit the oscillations
-        _gaussian_params, _ = curve_fit(gaussian_function, self.freqs, self._psd_flat,
+        gaussian_params, _ = curve_fit(gaussian_function, self.freqs, self._psd_flat,
                                         p0=guess, maxfev=5000, bounds=gaus_param_bounds)
 
         # Re-organize params into 2d matrix
-        _gaussian_params = np.array(group_three(_gaussian_params))
+        gaussian_params = np.array(group_three(gaussian_params))
 
-        return _gaussian_params
+        return gaussian_params
 
 
     def _drop_osc_cf(self, osc_params):
@@ -529,7 +501,7 @@ class FOOOF(object):
         """
 
         cf_params = [item[0] for item in osc_params]
-        bw_params = [item[2] * self._bw_std_thresh for item in osc_params]
+        bw_params = [item[2] * self._bw_std_edge for item in osc_params]
 
         # Drop if within 1 BW (std. dev) of the edge
         keep_parameter = \


### PR DESCRIPTION
Updates from amplitude exploration:

Changes:
- New kwargs for increased user control or fitting, in terms of amp & # oscs.
- Fix an error in which it would fail if no oscs guesses were found
- No longer drop negative values in flat PSD (I think this was leftover in error)
- Small clean ups on variables names. 

Things tried (didn't make it in):
- Compare to single, initial st. dev, instead of iterative (no dice)
- Try a more explicit 'outlier detection', using IQR (no better)

Note:
- Although some of the above helps tune, no fundamental change / fix for amplitude detection, other than allowing for user tuning. 
- I tried thinking of an approach more based on the distribution of the residuals, but not sure exactly how to proceed with that. 