### PR TITLE
Update names for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ FOOOF is a fast, efficient, and physiologically-informed tool to parameterize ne
 ## Overview
 
 FOOOF conceives of a model of the power spectrum as a combination of two distinct functional processes:
-- An aperiodic 'background' component, reflecting 1/f like characteristics, modeled with an exponential fit, with
-- A variable number of periodic components, that exhibit as band-limited peaks rising above this background, reflecting putative oscillations, modeled as Gaussians
+- An aperiodic component, reflecting 1/f like characteristics, modeled with an exponential fit, with
+- A variable number of periodic components, that exhibit as band-limited peaks rising above the aperiodic component, reflecting putative oscillations, modeled as Gaussians
 
-With regards to examining peaks in the frequency domain, as putative oscillations, the benefit of the FOOOF approach is that these peaks are characterized in terms of their specific center frequency, amplitude and bandwidth without requiring predefining specific bands of interest. In particular, it separates these peaks from a dynamic, and independently interesting aperiodic background. This conception of the aperiodic background, as potentially functional (and therefore worth carefully modeling) is based on work from our lab suggesting that the slope of this approximately 1/f distributed aperiodic background may reflect physiological parameters, particularly excitation/inhibition balance ([Gao, Peterson, Voytek, _NeuroImage_ 2017](http://voyteklab.com/wp-content/uploads/Gao-NeuroImage2017.pdf); [Voytek & Knight, _Biol Psychiatry_ 2015](http://voyteklab.com/wp-content/uploads/Voytek-BiolPsychiatry2015.pdf)). This aperiodic component changes with task ([Podvalny _et al._, _J Neurophysiol_ 2015](http://www.weizmann.ac.il/neurobiology/labs/malach/sites/neurobiology.labs.malach/files/Podvalny%20et%20al_2015_JNeurophysiol.pdf)), with aging ([Voytek _et al._, _J Neurosci_ 2015](http://voyteklab.com/wp-content/uploads/Voytek-JNeurosci2015.pdf)), and is thus interesting and important to measure, both in of itself, and to address potential confounds of the aperiodic components on the measurement of band-limited periodic components.
+With regards to examining peaks in the frequency domain, as putative oscillations, the benefit of the FOOOF approach is that these peaks are characterized in terms of their specific center frequency, amplitude and bandwidth without requiring predefining specific bands of interest. In particular, it separates these peaks from a dynamic, and independently interesting aperiodic component. This conception of the aperiodic component, as potentially functional (and therefore worth carefully modeling) is based on work from our lab suggesting that the properties of this approximately 1/f distributed aperiodic component may reflect physiological parameters, particularly excitation/inhibition balance ([Gao, Peterson, Voytek, _NeuroImage_ 2017](http://voyteklab.com/wp-content/uploads/Gao-NeuroImage2017.pdf); [Voytek & Knight, _Biol Psychiatry_ 2015](http://voyteklab.com/wp-content/uploads/Voytek-BiolPsychiatry2015.pdf)). This aperiodic component changes with task ([Podvalny _et al._, _J Neurophysiol_ 2015](http://www.weizmann.ac.il/neurobiology/labs/malach/sites/neurobiology.labs.malach/files/Podvalny%20et%20al_2015_JNeurophysiol.pdf)), with aging ([Voytek _et al._, _J Neurosci_ 2015](http://voyteklab.com/wp-content/uploads/Voytek-JNeurosci2015.pdf)), and is thus interesting and important to measure, both in of itself, and to address potential confounds of the aperiodic components on the measurement of band-limited periodic components.
 
 A full description of the method and approach is available in the paper below.
 
@@ -104,7 +104,7 @@ freq_range = [3, 40]
 fm.report(freqs, spectrum, freq_range)
 ```
 
-FOOOF.report() fits the model, plots the original power spectrum with the associated FOOOF model fit, and prints out the parameters of the model fit for both aperiodic 'background' and Gaussian parameters for any identified peaks.
+FOOOF.report() fits the model, plots the original power spectrum with the associated FOOOF model fit, and prints out the parameters of the model fit for both the aperiodic component, and parameters for any identified peaks, reflecting periodic components.
 
 FOOOF also accepts parameters for fine-tuning the fit. For example:
 
@@ -114,7 +114,7 @@ fm = FOOOF(peak_width_limits=[1.0, 8.0], max_n_peaks=6, min_peak_amplitude=0.1, 
 
 * _peak_width_limits_ sets the possible lower- and upper-bounds for the fitted peak widths.
 * _max_n_peaks_ sets the maximum number of peaks to fit (in decreasing order of amplitude).
-* _min_peak_amp_ sets an absolute limit on the minimum amplitude (above background) for any extracted peak.
+* _min_peak_amp_ sets an absolute limit on the minimum amplitude (above aperiodic) for any extracted peak.
 * _peak_threshold_, also sets a threshold above which a peak amplitude must cross to be included in the model. This parameter is in terms of standard deviation above the noise of the flattened spectrum.
 
 FOOOF also has convenience methods for running the FOOOF model across matrices of multiple power spectra, as well as functionality for saving and loading results, creating reports from FOOOF outputs, and utilities to further analize FOOOF results.

--- a/fooof/core/funcs.py
+++ b/fooof/core/funcs.py
@@ -146,49 +146,49 @@ def quadratic_function(xs, *params):
     return ys
 
 
-def get_bg_func(background_mode):
-    """Select and return specified function for background process.
+def get_ap_func(aperiodic_mode):
+    """Select and return specified function for fitting aperiodic component.
 
     Parameters
     ----------
-    background_mode : {'fixed', 'knee'}
-        Which kind of background function to return.
+    aperiodic_mode : {'fixed', 'knee'}
+        Which aperiodic fitting function to return.
 
     Returns
     -------
-    bg_func : function
-        Function for the background process.
+    ap_func : function
+        Function for the aperiodic process.
     """
 
-    if background_mode == 'fixed':
-        bg_func = expo_nk_function
-    elif background_mode == 'knee':
-        bg_func = expo_function
+    if aperiodic_mode == 'fixed':
+        ap_func = expo_nk_function
+    elif aperiodic_mode == 'knee':
+        ap_func = expo_function
     else:
-        raise ValueError('Background mode not understood.')
+        raise ValueError('Aperiodic mode not understood.')
 
-    return bg_func
+    return ap_func
 
 
-def infer_bg_func(background_params):
-    """Infers which background function was used, from parameters.
+def infer_ap_func(aperiodic_params):
+    """Infers which aperiodic function was used, from parameters.
 
     Parameters
     ----------
-    background_params : list of float
-        Parameters that describe the background of a power spectrum.
+    aperiodic_params : list of float
+        Parameters that describe the aperiodic component of a power spectrum.
 
     Returns
     -------
-    background_mode : {'fixed', 'knee'}
-        Which kind of background process parameters are consistent with.
+    aperiodic_mode : {'fixed', 'knee'}
+        Which kind of aperiodic fitting function parameters are consistent with.
     """
 
-    if len(background_params) == 2:
-        background_mode = 'fixed'
-    elif len(background_params) == 3:
-        background_mode = 'knee'
+    if len(aperiodic_params) == 2:
+        aperiodic_mode = 'fixed'
+    elif len(aperiodic_params) == 3:
+        aperiodic_mode = 'knee'
     else:
-        raise ValueError('Background parameters not consistent with any available option.')
+        raise ValueError('Aperiodic parameters not consistent with any available option.')
 
-    return background_mode
+    return aperiodic_mode

--- a/fooof/core/reports.py
+++ b/fooof/core/reports.py
@@ -87,7 +87,7 @@ def save_report_fg(fg, file_name, file_path=''):
     ax0.set_xticks([])
     ax0.set_yticks([])
 
-    # Background parameters plot
+    # Aperiodic parameters plot
     ax1 = plt.subplot(gs[1, 0])
     plot_fg_bg(fg, ax1)
 

--- a/fooof/core/strings.py
+++ b/fooof/core/strings.py
@@ -57,10 +57,10 @@ def gen_settings_str(f_obj, description=False, concise=False):
     """
 
     # Parameter descriptions to print out, if requested
-    desc = {'background_mode'       : 'The aproach taken to fitting the background.',
+    desc = {'aperiodic_mode'       : 'The aproach taken to fitting the aperiodic component.',
             'peak_width_limits'     : 'Enforced limits for peak widths, in Hz.',
             'max_n_peaks'           : 'The maximum number of peaks that can be extracted.',
-            'min_peak_amplitude'    : "Minimum absolute amplitude of a peak, above background.",
+            'min_peak_amplitude'    : "Minimum absolute amplitude of a peak, above aperiodic component.",
             'peak_threshold'    : "Threshold at which to stop searching for peaks."}
 
     # Clear description for printing if not requested
@@ -77,8 +77,8 @@ def gen_settings_str(f_obj, description=False, concise=False):
         '',
 
         # Settings - include descriptions if requested
-        *[el for el in ['Background Mode : {}'.format(f_obj.background_mode),
-                        '{}'.format(desc['background_mode']),
+        *[el for el in ['Aperiodic Mode : {}'.format(f_obj.aperiodic_mode),
+                        '{}'.format(desc['aperiodic_mode']),
                         'Peak Width Limits : {}'.format(f_obj.peak_width_limits),
                         '{}'.format(desc['peak_width_limits']),
                         'Max Number of Peaks : {}'.format(f_obj.max_n_peaks),
@@ -115,7 +115,7 @@ def gen_results_str_fm(fm, concise=False):
     """
 
     # Returns a null report if no results are available
-    if np.all(np.isnan(fm.background_params_)):
+    if np.all(np.isnan(fm.aperiodic_params_)):
         return _no_model_str(concise)
 
     # Create the formatted strings for printing
@@ -133,11 +133,11 @@ def gen_results_str_fm(fm, concise=False):
         'Frequency Resolution is {:1.2f} Hz'.format(fm.freq_res),
         '',
 
-        # Background parameters
-        ('Background Parameters (offset, ' + ('knee, ' if fm.background_mode == 'knee' else '') + \
-           'slope): '),
-        ', '.join(['{:2.4f}'] * len(fm.background_params_)).format(
-            *fm.background_params_),
+        # Aperiodic parameters
+        ('Aperiodic Parameters (offset, ' + ('knee, ' if fm.aperiodic_mode == 'knee' else '') + \
+           'exponent): '),
+        ', '.join(['{:2.4f}'] * len(fm.aperiodic_params_)).format(
+            *fm.aperiodic_params_),
         '',
 
         # Peak parameters
@@ -186,12 +186,12 @@ def gen_results_str_fg(fg, concise=False):
     n_peaks = len(fg.get_all_data('peak_params'))
     r2s = fg.get_all_data('r_squared')
     errors = fg.get_all_data('error')
-    if fg.background_mode == 'knee':
-        kns = fg.get_all_data('background_params', 1)
-        sls = fg.get_all_data('background_params', 2)
+    if fg.aperiodic_mode == 'knee':
+        kns = fg.get_all_data('aperiodic_params', 1)
+        sls = fg.get_all_data('aperiodic_params', 2)
     else:
         kns = np.array([0])
-        sls = fg.get_all_data('background_params', 1)
+        sls = fg.get_all_data('aperiodic_params', 1)
 
     # Check if there are any power spectra that failed to fit
     n_failed = sum(np.isnan(sls))
@@ -215,14 +215,14 @@ def gen_results_str_fg(fg, concise=False):
         'Frequency Resolution is {:1.2f} Hz'.format(fg.freq_res),
         '',
 
-        # Background parameters - knee fit status, and quick slope description
-        'Power spectra were fit {} a knee.'.format('with' if fg.background_mode == 'knee' else 'without'),
+        # Aperiodic parameters - knee fit status, and quick exponent description
+        'Power spectra were fit {} a knee.'.format('with' if fg.aperiodic_mode == 'knee' else 'without'),
         '',
-        *[el for el in ['Background Knee Values',
+        *[el for el in ['Aperiodic Knee Values',
                         'Min: {:6.2f}, Max: {:6.2f}, Mean: {:5.2f}'
                         .format(np.nanmin(kns), np.nanmax(kns), np.nanmean(kns)),
-                       ] if fg.background_mode == 'knee'],
-        'Background Slope Values',
+                       ] if fg.aperiodic_mode == 'knee'],
+        'Aperiodic Exponent Values',
         'Min: {:6.4f}, Max: {:6.4f}, Mean: {:5.4f}'
         .format(np.nanmin(sls), np.nanmax(sls), np.nanmean(sls)),
         '',

--- a/fooof/core/utils.py
+++ b/fooof/core/utils.py
@@ -109,25 +109,25 @@ def get_obj_desc():
         Mapping of FOOOF object attributes, and what kind of data they are.
     """
 
-    attributes = {'results' : ['background_params_', 'peak_params_', 'error_',
+    attributes = {'results' : ['aperiodic_params_', 'peak_params_', 'error_',
                                'r_squared_', '_gaussian_params'],
                   'settings' : ['peak_width_limits', 'max_n_peaks', 'min_peak_amplitude',
-                                'peak_threshold', 'background_mode'],
+                                'peak_threshold', 'aperiodic_mode'],
                   'data' : ['power_spectrum', 'freq_range', 'freq_res'],
                   'freq_info' : ['freq_range', 'freq_res'],
-                  'arrays' : ['freqs', 'power_spectrum', 'background_params_',
+                  'arrays' : ['freqs', 'power_spectrum', 'aperiodic_params_',
                               'peak_params_', '_gaussian_params']}
 
     return attributes
 
 
-def get_data_indices(background_mode):
+def get_data_indices(aperiodic_mode):
     """Get a dictionary mapping the column labels to indices in FOOOF data (FOOOFResults).
 
     Parameters
     ----------
-    background_mode : {'fixed', 'knee'}
-        Which approach taken to fit the background.
+    aperiodic_mode : {'fixed', 'knee'}
+        Which approach taken to fit the aperiodic component.
 
     Returns
     -------
@@ -140,8 +140,8 @@ def get_data_indices(background_mode):
         'Amp' : 1,
         'BW'  : 2,
         'intercept' : 0,
-        'knee'      : 1 if background_mode == 'knee' else None,
-        'slope'     : 1 if background_mode == 'fixed' else 2
+        'knee'      : 1 if aperiodic_mode == 'knee' else None,
+        'exponent'  : 1 if aperiodic_mode == 'fixed' else 2
     }
 
     return indices

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -178,11 +178,11 @@ class FOOOFGroup(FOOOF):
 
         Parameters
         ----------
-        name : {'background_params', 'peak_params', 'error', 'r_squared', 'gaussian_params'}
+        name : {'aperiodic_params', 'peak_params', 'error', 'r_squared', 'gaussian_params'}
             Name of the data field to extract across the group.
-        col : {'CF', 'Amp', 'BW', 'intercept', 'knee', 'slope'} or int, optional
+        col : {'CF', 'Amp', 'BW', 'intercept', 'knee', 'exponent'} or int, optional
             Column name / index to extract from selected data, if requested.
-                Only used for name of {'background_params', 'peak_params', 'gaussian_params'}.
+                Only used for name of {'aperiodic_params', 'peak_params', 'gaussian_params'}.
 
         Returns
         -------
@@ -198,7 +198,7 @@ class FOOOFGroup(FOOOF):
 
         # If col specified as string, get mapping back to integer
         if isinstance(col, str):
-            col = get_data_indices(self.background_mode)[col]
+            col = get_data_indices(self.aperiodic_mode)[col]
 
         # Pull out the requested data field from the group data
         # As a special case, peak_params are pulled out in a way that appends
@@ -292,7 +292,7 @@ class FOOOFGroup(FOOOF):
 
         # Initialize a FOOOF object, with same settings as current FOOOFGroup
         fm = FOOOF(self.peak_width_limits, self.max_n_peaks, self.min_peak_amplitude,
-                   self.peak_threshold, self.background_mode, self.verbose)
+                   self.peak_threshold, self.aperiodic_mode, self.verbose)
 
         # Add data for specified single power spectrum, if available
         #  The power spectrum is inverted back to linear, as it's re-logged when added to FOOOF

--- a/fooof/plts/fg.py
+++ b/fooof/plts/fg.py
@@ -38,7 +38,7 @@ def plot_fg(fg, save_fig=False, file_name='FOOOF_group_fit', file_path=''):
     fig = plt.figure(figsize=(14, 10))
     gs = gridspec.GridSpec(2, 2, wspace=0.35, hspace=0.25, height_ratios=[1, 1.2])
 
-    # Background parameters plot
+    # Aperiodic parameters plot
     ax0 = plt.subplot(gs[0, 0])
     plot_fg_bg(fg, ax0)
 
@@ -56,7 +56,7 @@ def plot_fg(fg, save_fig=False, file_name='FOOOF_group_fit', file_path=''):
 
 @check_dependency(plt, 'matplotlib')
 def plot_fg_bg(fg, ax=None):
-    """Plot background fit parameters, in a scatter plot.
+    """Plot aperiodic fit parameters, in a scatter plot.
 
     Parameters
     ----------
@@ -66,13 +66,13 @@ def plot_fg_bg(fg, ax=None):
         Figure axes upon which to plot.
     """
 
-    if fg.background_mode == 'knee':
-        plot_scatter_2(fg.get_all_data('background_params', 1), 'Knee',
-                       fg.get_all_data('background_params', 2), 'Slope',
-                       'Background Fit', ax=ax)
+    if fg.aperiodic_mode == 'knee':
+        plot_scatter_2(fg.get_all_data('aperiodic_params', 1), 'Knee',
+                       fg.get_all_data('aperiodic_params', 2), 'Exponent',
+                       'Aperiodic Fit', ax=ax)
     else:
-        plot_scatter_1(fg.get_all_data('background_params', 1), 'Slope',
-                       'Background Fit', ax=ax)
+        plot_scatter_1(fg.get_all_data('aperiodic_params', 1), 'Exponent',
+                       'Aperiodic Fit', ax=ax)
 
 
 @check_dependency(plt, 'matplotlib')

--- a/fooof/plts/fm.py
+++ b/fooof/plts/fm.py
@@ -54,9 +54,9 @@ def plot_fm(fm, plt_log=False, save_fig=False, file_name='FOOOF_fit', file_path=
     if np.any(fm.fooofed_spectrum_):
         plot_spectrum(fm.freqs, fm.fooofed_spectrum_, log_freqs, log_powers, ax,
                       color='r', linewidth=3.0, alpha=0.5, label='Full Model Fit')
-        plot_spectrum(fm.freqs, fm._bg_fit, log_freqs, log_powers, ax,
+        plot_spectrum(fm.freqs, fm._ap_fit, log_freqs, log_powers, ax,
                       color='b', linestyle='dashed', linewidth=3.0,
-                      alpha=0.5, label='Background Fit')
+                      alpha=0.5, label='Aperiodic Fit')
 
     # Save out figure, if requested
     if save_fig:

--- a/fooof/synth/params.py
+++ b/fooof/synth/params.py
@@ -9,7 +9,7 @@ from fooof.core.utils import check_flat
 ###################################################################################################
 ###################################################################################################
 
-SynParams = namedtuple('SynParams', ['background_params', 'gaussian_params', 'nlv'])
+SynParams = namedtuple('SynParams', ['aperiodic_params', 'gaussian_params', 'nlv'])
 
 class Stepper():
     """Object for stepping across parameter values.

--- a/fooof/tests/test_core_funcs.py
+++ b/fooof/tests/test_core_funcs.py
@@ -85,28 +85,28 @@ def test_quadratic_function():
     assert np.isclose(sl_meas, sl)
     assert np.isclose(curve_meas, curve)
 
-def test_get_bg_func():
+def test_get_ap_func():
 
-    bgf_nk = get_bg_func('fixed')
+    bgf_nk = get_ap_func('fixed')
     assert bgf_nk
 
-    bgf_kn = get_bg_func('knee')
+    bgf_kn = get_ap_func('knee')
     assert bgf_kn
 
     # Check error
     with raises(ValueError):
-        get_bg_func('bad')
+        get_ap_func('bad')
 
-def test_infer_bg_func():
+def test_infer_ap_func():
 
     bgp_nk = [50, 1]
-    bgm_nk = infer_bg_func(bgp_nk)
+    bgm_nk = infer_ap_func(bgp_nk)
     assert bgm_nk == 'fixed'
 
     bgp_kn = [50, 2, 1]
-    bgm_kn = infer_bg_func(bgp_kn)
+    bgm_kn = infer_ap_func(bgp_kn)
     assert bgm_kn == 'knee'
 
     # Check error
     with raises(ValueError):
-        infer_bg_func([1, 2, 3, 4])
+        infer_ap_func([1, 2, 3, 4])

--- a/fooof/tests/test_fit.py
+++ b/fooof/tests/test_fit.py
@@ -36,8 +36,8 @@ def test_fooof_fit_nk():
     tfm = FOOOF()
     tfm.fit(xs, ys)
 
-    # Check model results - background parameters
-    assert np.all(np.isclose(bgp, tfm.background_params_, [0.5, 0.1]))
+    # Check model results - aperiodic parameters
+    assert np.all(np.isclose(bgp, tfm.aperiodic_params_, [0.5, 0.1]))
 
     # Check model results - gaussian parameters
     for ii, gauss in enumerate(group_three(gauss_params)):
@@ -51,7 +51,7 @@ def test_fooof_fit_knee():
 
     xs, ys = gen_power_spectrum([3, 50], bgp, gauss_params)
 
-    tfm = FOOOF(background_mode='knee')
+    tfm = FOOOF(aperiodic_mode='knee')
     tfm.fit(xs, ys)
 
     # Note: currently, this test has no accuracy checking at all
@@ -142,9 +142,9 @@ def test_fooof_resets():
 
     assert tfm.freqs is None and tfm.freq_range is None and tfm.freq_res is None  \
         and tfm.power_spectrum is None and tfm.fooofed_spectrum_ is None and tfm._spectrum_flat is None \
-        and tfm._spectrum_peak_rm is None and tfm._bg_fit is None and tfm._peak_fit is None
+        and tfm._spectrum_peak_rm is None and tfm._ap_fit is None and tfm._peak_fit is None
 
-    assert np.all(np.isnan(tfm.background_params_)) and np.all(np.isnan(tfm.peak_params_)) \
+    assert np.all(np.isnan(tfm.aperiodic_params_)) and np.all(np.isnan(tfm.peak_params_)) \
         and np.all(np.isnan(tfm.r_squared_)) and np.all(np.isnan(tfm.error_)) and np.all(np.isnan(tfm._gaussian_params))
 
 def test_fooof_report(skip_if_no_mpl):

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -52,7 +52,7 @@ def test_fg_fit():
     assert out
     assert len(out) == n_spectra
     assert isinstance(out[0], FOOOFResult)
-    assert np.all(out[1].background_params)
+    assert np.all(out[1].aperiodic_params)
 
 def test_fg_fit_par():
     """Test FOOOFGroup fit, running in parallel."""
@@ -67,7 +67,7 @@ def test_fg_fit_par():
     assert out
     assert len(out) == n_spectra
     assert isinstance(out[0], FOOOFResult)
-    assert np.all(out[1].background_params)
+    assert np.all(out[1].aperiodic_params)
 
 def test_fg_print(tfg):
     """Check print method (alias)."""
@@ -83,11 +83,11 @@ def test_get_results(tfg):
 def test_get_all_data(tfg):
     """Check get_all_data method."""
 
-    for dname in ['background_params', 'peak_params', 'error', 'r_squared', 'gaussian_params']:
+    for dname in ['aperiodic_params', 'peak_params', 'error', 'r_squared', 'gaussian_params']:
         assert np.any(tfg.get_all_data(dname))
 
-        if dname == 'background_params':
-            for dtype in ['intercept', 'slope']:
+        if dname == 'aperiodic_params':
+            for dtype in ['intercept', 'exponent']:
                 assert np.any(tfg.get_all_data(dname, dtype))
 
         if dname == 'peak_params':

--- a/fooof/tests/test_synth_gen.py
+++ b/fooof/tests/test_synth_gen.py
@@ -53,22 +53,22 @@ def test_gen_group_power_spectra_empty_gauss():
     assert np.all(ys)
     assert ys.ndim == n_spectra
 
-def test_gen_background():
+def test_gen_aperiodic():
 
     xs = gen_freqs([3, 50], 0.5)
 
     bgp_nk = [50, 2]
-    bgv_nk = gen_background(xs, bgp_nk, 'fixed')
+    bgv_nk = gen_aperiodic(xs, bgp_nk, 'fixed')
     assert np.all(bgv_nk)
 
     bgp_kn = [50, 1, 1]
-    bgv_kn = gen_background(xs, bgp_kn, 'knee')
+    bgv_kn = gen_aperiodic(xs, bgp_kn, 'knee')
     assert np.all(bgv_kn)
 
-    # Check without specifying background mode
-    bgv_nk_2 = gen_background(xs, bgp_nk)
+    # Check without specifying aperiodic mode
+    bgv_nk_2 = gen_aperiodic(xs, bgp_nk)
     assert np.array_equal(bgv_nk, bgv_nk_2)
-    bgv_kn_2 = gen_background(xs, bgp_kn)
+    bgv_kn_2 = gen_aperiodic(xs, bgp_kn)
     assert np.array_equal(bgv_kn, bgv_kn_2)
 
 def test_gen_peaks():

--- a/fooof/tests/test_synth_params.py
+++ b/fooof/tests/test_synth_params.py
@@ -21,7 +21,7 @@ def test_param_iter():
     for ind, val in enumerate(iter_1):
         assert val == [8 + (.1*ind), .5 , .5]
 
-    # Test background
+    # Test aperiodic
     step = Stepper(.25, 3, .25)
     bg = [0, step]
     iter_1 = param_iter(bg)


### PR DESCRIPTION
Update codebase to reflect new naming scheme for 1.0 release. Responds to #77 

This update breaks backwards compatibility with the 0.1.X versions. 

Notes: 
- merge PR #121 first, as this branch includes updates from there. 
- still need to update the pictures, which include figures with outdated labels