### PR TITLE
Refactor & update fooof.synth.transform

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -89,7 +89,11 @@ Transforming Power Spectra
 .. autosummary::
     :toctree: generated/
 
+    translate_spectrum
+    translate_syn_spectrum
     rotate_spectrum
+    rotate_syn_spectrum
+    calc_rotation_offset
 
 Plotting Functions
 ------------------

--- a/fooof/core/utils.py
+++ b/fooof/core/utils.py
@@ -139,7 +139,7 @@ def get_data_indices(aperiodic_mode):
         'CF'  : 0,
         'Amp' : 1,
         'BW'  : 2,
-        'intercept' : 0,
+        'offset' : 0,
         'knee'      : 1 if aperiodic_mode == 'knee' else None,
         'exponent'  : 1 if aperiodic_mode == 'fixed' else 2
     }

--- a/fooof/fit.py
+++ b/fooof/fit.py
@@ -60,7 +60,7 @@ The resulting parameters and associated data of a FOOOF model fit.
 Attributes
 ----------
 aperiodic_params : 1d array, len 2 or 3
-    Parameters that define the aperiodic fit. As [Intercept, (Knee), Exponent].
+    Parameters that define the aperiodic fit. As [Offset, (Knee), Exponent].
         The knee parameter is only included if aperiodic is fit with knee. Otherwise, length is 2.
 peak_params : 2d array, shape=[n_peaks, 3]
     Fitted parameter values for the peaks. Each row is a peak, as [CF, Amp, BW].
@@ -108,7 +108,7 @@ class FOOOF(object):
     fooofed_spectrum_ : 1d array
         The full model fit of the power spectrum, in log10 scale
     aperiodic_params_ : 1d array
-        Parameters that define the aperiodic fit. As [Intercept, (Knee), Exponent].
+        Parameters that define the aperiodic fit. As [Offset, (Knee), Exponent].
         The knee parameter is only included if aperiodic component is fit with a knee.
     peak_params_ : 2d array
         Fitted parameter values for the peaks. Each row is a peak, as [CF, Amp, BW].

--- a/fooof/group.py
+++ b/fooof/group.py
@@ -180,7 +180,7 @@ class FOOOFGroup(FOOOF):
         ----------
         name : {'aperiodic_params', 'peak_params', 'error', 'r_squared', 'gaussian_params'}
             Name of the data field to extract across the group.
-        col : {'CF', 'Amp', 'BW', 'intercept', 'knee', 'exponent'} or int, optional
+        col : {'CF', 'Amp', 'BW', 'offset', 'knee', 'exponent'} or int, optional
             Column name / index to extract from selected data, if requested.
             Only used for name of {'aperiodic_params', 'peak_params', 'gaussian_params'}.
 

--- a/fooof/synth/gen.py
+++ b/fooof/synth/gen.py
@@ -33,7 +33,7 @@ def gen_freqs(freq_range, freq_res):
     return freqs
 
 
-def gen_power_spectrum(freq_range, aperiodic_params, gauss_params, nlv=0.005, freq_res=0.5):
+def gen_power_spectrum(freq_range, aperiodic_params, gaussian_params, nlv=0.005, freq_res=0.5):
     """Generate a synthetic power spectrum.
 
     Parameters
@@ -42,7 +42,7 @@ def gen_power_spectrum(freq_range, aperiodic_params, gauss_params, nlv=0.005, fr
         Minimum and maximum values of the desired frequency vector.
     aperiodic_params : list of float
         Parameters to create the aperiodic component of a power spectrum. Length of 2 or 3 (see note).
-    gauss_params : list of float or list of list of float
+    gaussian_params : list of float or list of list of float
         Parameters to create peaks. Total length of n_peaks * 3 (see note).
     nlv : float, optional, default: 0.005
         Noise level to add to generated power spectrum.
@@ -87,13 +87,13 @@ def gen_power_spectrum(freq_range, aperiodic_params, gauss_params, nlv=0.005, fr
     """
 
     freqs = gen_freqs(freq_range, freq_res)
-    powers = gen_power_vals(freqs, aperiodic_params, check_flat(gauss_params), nlv)
+    powers = gen_power_vals(freqs, aperiodic_params, check_flat(gaussian_params), nlv)
 
     return freqs, powers
 
 
 def gen_group_power_spectra(n_spectra, freq_range, aperiodic_params,
-                            gauss_params, nlvs=0.005, freq_res=0.5):
+                            gaussian_params, nlvs=0.005, freq_res=0.5):
     """Generate a group of synthetic power spectra.
 
     Parameters
@@ -104,7 +104,7 @@ def gen_group_power_spectra(n_spectra, freq_range, aperiodic_params,
         Minimum and maximum values of the desired frequency vector.
     aperiodic_params : list of float or generator
         Parameters for the aperiodic component of the power spectra.
-    gauss_params : list of float or generator
+    gaussian_params : list of float or generator
         Parameters for the peaks of the power spectra.
             Length of n_peaks * 3.
     nlvs : float or list of float or generator, optional, default: 0.005
@@ -164,11 +164,11 @@ def gen_group_power_spectra(n_spectra, freq_range, aperiodic_params,
 
     # Check if inputs are generators, if not, make them into repeat generators
     aperiodic_params = check_iter(aperiodic_params, n_spectra)
-    gauss_params = check_iter(gauss_params, n_spectra)
+    gaussian_params = check_iter(gaussian_params, n_spectra)
     nlvs = check_iter(nlvs, n_spectra)
 
     # Synthesize power spectra
-    for ind, bgp, gp, nlv in zip(range(n_spectra), aperiodic_params, gauss_params, nlvs):
+    for ind, bgp, gp, nlv in zip(range(n_spectra), aperiodic_params, gaussian_params, nlvs):
 
         syn_params[ind] = SynParams(bgp.copy(), sorted(group_three(gp)), nlv)
         powers[ind, :] = gen_power_vals(freqs, bgp, gp, nlv)
@@ -205,14 +205,14 @@ def gen_aperiodic(freqs, aperiodic_params, aperiodic_mode=None):
     return ap_vals
 
 
-def gen_peaks(freqs, gauss_params):
+def gen_peaks(freqs, gaussian_params):
     """Generate peaks values, from parameter definition.
 
     Parameters
     ----------
     freqs : 1d array
         Frequency vector to create peak values from.
-    gauss_params : list of float
+    gaussian_params : list of float
         Parameters to create peaks. Length of n_peaks * 3.
 
     Returns
@@ -221,12 +221,12 @@ def gen_peaks(freqs, gauss_params):
         Generated aperiodic values.
     """
 
-    peak_vals = gaussian_function(freqs, *gauss_params)
+    peak_vals = gaussian_function(freqs, *gaussian_params)
 
     return peak_vals
 
 
-def gen_power_vals(freqs, aperiodic_params, gauss_params, nlv):
+def gen_power_vals(freqs, aperiodic_params, gaussian_params, nlv):
     """Generate power values for a power spectrum.
 
     Parameters
@@ -235,7 +235,7 @@ def gen_power_vals(freqs, aperiodic_params, gauss_params, nlv):
         Frequency vector to create power values from.
     aperiodic_params : list of float
         Parameters to create the aperiodic component of the power spectrum.
-    gauss_params : list of float
+    gaussian_params : list of float
         Parameters to create peaks. Length of n_peaks * 3.
     nlv : float
         Noise level to add to generated power spectrum.
@@ -247,7 +247,7 @@ def gen_power_vals(freqs, aperiodic_params, gauss_params, nlv):
     """
 
     aperiodic = gen_aperiodic(freqs, aperiodic_params)
-    peaks = gen_peaks(freqs, gauss_params)
+    peaks = gen_peaks(freqs, gaussian_params)
     noise = np.random.normal(0, nlv, len(freqs))
 
     powers = np.power(10, aperiodic + peaks + noise)

--- a/fooof/synth/params.py
+++ b/fooof/synth/params.py
@@ -4,7 +4,8 @@ from collections import namedtuple
 
 import numpy as np
 
-from fooof.core.utils import check_flat
+from fooof.core.utils import check_flat, get_data_indices
+from fooof.core.funcs import infer_ap_func
 
 ###################################################################################################
 ###################################################################################################
@@ -16,14 +17,57 @@ Stores parameters used to synthesize a single power spectra.
 
 Attributes
 ----------
-aperiodic_params : 1d array, len 2 or 3
+aperiodic_params : list, len 2 or 3
     Parameters that define the aperiodic fit. As [Intercept, (Knee), Exponent].
         The knee parameter is only included if aperiodic is fit with knee. Otherwise, length is 2.
-gaussian_params : 2d array, shape=[n_peaks, 3]
-    Fitted parameter values for the peaks. Each row is a peak, as [CF, Amp, BW].
+gaussian_params : list or list of lists
+    Fitted parameter values for the peaks. Each list is a peak, as [CF, Amp, BW].
 nlv : float
     Noise level added to the generated power spectrum.
 """
+
+def update_syn_ap_params(syn_params, delta, field=None):
+    """Update the aperiodic parameter definition in a SynParams object.
+
+    Parameters
+    ----------
+    syn_params : SynParams object
+        Object storing the current parameter definitions.
+    delta : float or list
+        Value(s) by which to update the parameters.
+    field : {'offset', 'knee', 'exponent'} or list of string
+        Field of the aperiodic parameters to update.
+
+    Returns
+    -------
+    new_syn_params : SynParams object
+        Updated object storing the new parameter definitions.
+
+    Notes
+    -----
+    SynParams is a `namedtuple`, which is immutable.
+    Therefore, this function constructs and returns a new `SynParams` object.
+    """
+
+    ap_params = syn_params.aperiodic_params.copy()
+
+    if not field:
+        if not len(ap_params) == len(delta):
+            raise ValueError('')
+        ap_params = [ii + jj for ii, jj in zip(ap_params, delta)]
+
+    else:
+        field = list([field]) if not isinstance(field, list) else field
+        delta = list([delta]) if not isinstance(delta, list) else delta
+
+        for cur_field, cur_delta in zip(field, delta):
+            dat_ind = get_data_indices(infer_ap_func(syn_params.aperiodic_params))[cur_field]
+            ap_params[dat_ind] = ap_params[dat_ind] + cur_delta
+
+    new_syn_params = SynParams(ap_params, *syn_params[1:])
+
+    return new_syn_params
+
 
 class Stepper():
     """Object for stepping across parameter values.

--- a/fooof/synth/params.py
+++ b/fooof/synth/params.py
@@ -18,7 +18,7 @@ Stores parameters used to synthesize a single power spectra.
 Attributes
 ----------
 aperiodic_params : list, len 2 or 3
-    Parameters that define the aperiodic fit. As [Intercept, (Knee), Exponent].
+    Parameters that define the aperiodic fit. As [Offset, (Knee), Exponent].
         The knee parameter is only included if aperiodic is fit with knee. Otherwise, length is 2.
 gaussian_params : list or list of lists
     Fitted parameter values for the peaks. Each list is a peak, as [CF, Amp, BW].

--- a/fooof/synth/transform.py
+++ b/fooof/synth/transform.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 
+from fooof.synth.params import update_syn_ap_params
+
 ###################################################################################################
 ###################################################################################################
 
@@ -15,11 +17,11 @@ def rotate_spectrum(freqs, power_spectrum, delta, f_rotation):
     power_spectrum : 1d array
         Power values of the spectrum that is to be rotated.
     delta : float
-        Change in power law exponent to be applied.
+        Change in aperiodic exponent to be applied.
         Positive is counterclockwise rotation (flatten).
         Negative is clockwise rotation (steepen).
     f_rotation : float
-        Frequency (Hz) at which to do the rotation, such that power at that frequency is unchanged.
+        Frequency value, in Hz, about which rotation is applied, at which power is unchanged.
 
     Returns
     -------
@@ -56,7 +58,82 @@ def translate_spectrum(power_spectrum, delta):
     return translated_spectrum
 
 
+def rotate_syn_spectrum(freqs, power_spectrum, delta, f_rotation, syn_params):
+    """Rotate a power spectrum about a frequency point, changing the power law exponent.
+
+    Parameters
+    ----------
+    freqs : 1d array
+        Frequency axis of input power spectrum, in Hz.
+    power_spectrum : 1d array
+        Power values of the spectrum that is to be rotated.
+    delta : float
+        Change in aperiodic exponent to be applied.
+        Positive is counterclockwise rotation (flatten).
+        Negative is clockwise rotation (steepen).
+    f_rotation : float
+        Frequency value, in Hz, about which rotation is applied, at which power is unchanged.
+    syn_params : SynParams object
+        Object storing the current parameter definitions.
+
+    Returns
+    -------
+    rotated_spectrum : 1d array
+        Rotated power spectrum.
+    new_syn_params : SynParams object
+        Updated object storing the new parameter definitions.
+    """
+
+    rotated_spectrum = rotate_spectrum(freqs, power_spectrum, delta, f_rotation)
+    delta_offset = calc_rot_offset(delta, f_rotation)
+
+    new_syn_params = update_syn_ap_params(syn_params, [delta_offset, delta])
+
+    return rotated_spectrum, new_syn_params
+
+
+def translate_syn_spectrum(power_spectrum, delta, syn_params):
+    """Translate a spectrum, changing the offset value.
+
+    Parameters
+    ----------
+    power_spectrum : 1d array
+        Power values of the spectrum that is to be translated.
+    delta : float
+        Amount to change the offset by.
+        Positive is an upwards translation.
+        Negative is a downwards translation.
+    syn_params : SynParams object
+        Object storing the current parameter definitions.
+
+    Returns
+    -------
+    translated_spectrum : 1d array
+        Translated power spectrum.
+    new_syn_params : SynParams object
+        Updated object storing the new parameter definitions.
+    """
+
+    translated_spectrum = translate_spectrum(power_spectrum, delta)
+    new_syn_params = update_syn_ap_params(syn_params, delta, 'intercept')
+
+    return translated_spectrum, new_syn_params
+
+
 def calc_rot_offset(delta, f_rotation):
-    """Calculate the change in offset from a given rotation"""
+    """Calculate the change in offset from a given rotation.
+
+    Parameters
+    ----------
+    delta : float
+        Change in aperiodic exponent to be applied.
+    f_rotation : float
+        Frequency value, in Hz, about which rotation is applied, at which power is unchanged.
+
+    Returns
+    -------
+    float
+        The amount the offset will change for the specified exponent change.
+    """
 
     return -np.log10(f_rotation) * delta

--- a/fooof/synth/transform.py
+++ b/fooof/synth/transform.py
@@ -27,21 +27,8 @@ def rotate_spectrum(freqs, power_spectrum, delta, f_rotation):
         Rotated power spectrum.
     """
 
-    # Check that the requested frequency rotation value is within the given range
-    if f_rotation < freqs.min() or f_rotation > freqs.max():
-        raise ValueError('Rotation frequency not within frequency range.')
-
-    f_mask = np.zeros_like(freqs)
-
-    f_mask = 10**(np.log10(np.abs(freqs)) * (delta))
-
-    # If starting freq is 0Hz, default power at 0Hz to keep same value because log will return inf.
-    if freqs[0] == 0.:
-        f_mask[0] = 1.
-
-    f_mask = f_mask / f_mask[np.where(freqs >= f_rotation)[0][0]]
-
-    rotated_spectrum = f_mask * power_spectrum
+    mask = (np.abs(freqs) / f_rotation)**delta
+    rotated_spectrum = mask * power_spectrum
 
     return rotated_spectrum
 
@@ -67,3 +54,9 @@ def translate_spectrum(power_spectrum, delta):
     translated_spectrum = np.power(10, delta, dtype='float') * power_spectrum
 
     return translated_spectrum
+
+
+def calc_rot_offset(delta, f_rotation):
+    """Calculate the change in offset from a given rotation"""
+
+    return -np.log10(f_rotation) * delta

--- a/fooof/synth/transform.py
+++ b/fooof/synth/transform.py
@@ -7,7 +7,7 @@ from fooof.synth.params import update_syn_ap_params
 ###################################################################################################
 ###################################################################################################
 
-def rotate_spectrum(freqs, power_spectrum, delta, f_rotation):
+def rotate_spectrum(freqs, power_spectrum, delta_exponent, f_rotation):
     """Rotate a power spectrum about a frequency point, changing the power law exponent.
 
     Parameters
@@ -16,7 +16,7 @@ def rotate_spectrum(freqs, power_spectrum, delta, f_rotation):
         Frequency axis of input power spectrum, in Hz.
     power_spectrum : 1d array
         Power values of the spectrum that is to be rotated.
-    delta : float
+    delta_exponent : float
         Change in aperiodic exponent to be applied.
         Positive is clockwise rotation (steepen).
         Negative is counterclockwise rotation (flatten).
@@ -29,20 +29,20 @@ def rotate_spectrum(freqs, power_spectrum, delta, f_rotation):
         Rotated power spectrum.
     """
 
-    mask = (np.abs(freqs) / f_rotation)**-delta
+    mask = (np.abs(freqs) / f_rotation)**-delta_exponent
     rotated_spectrum = mask * power_spectrum
 
     return rotated_spectrum
 
 
-def translate_spectrum(power_spectrum, delta):
+def translate_spectrum(power_spectrum, delta_offset):
     """Translate a spectrum, changing the offset value.
 
     Parameters
     ----------
     power_spectrum : 1d array
         Power values of the spectrum that is to be translated.
-    delta : float
+    delta_offset : float
         Amount to change the offset by.
         Positive is an upwards translation.
         Negative is a downwards translation.
@@ -53,12 +53,12 @@ def translate_spectrum(power_spectrum, delta):
         Translated power spectrum.
     """
 
-    translated_spectrum = np.power(10, delta, dtype='float') * power_spectrum
+    translated_spectrum = np.power(10, delta_offset, dtype='float') * power_spectrum
 
     return translated_spectrum
 
 
-def rotate_syn_spectrum(freqs, power_spectrum, delta, f_rotation, syn_params):
+def rotate_syn_spectrum(freqs, power_spectrum, delta_exponent, f_rotation, syn_params):
     """Rotate a power spectrum about a frequency point, changing the power law exponent.
 
     Parameters
@@ -67,7 +67,7 @@ def rotate_syn_spectrum(freqs, power_spectrum, delta, f_rotation, syn_params):
         Frequency axis of input power spectrum, in Hz.
     power_spectrum : 1d array
         Power values of the spectrum that is to be rotated.
-    delta : float
+    delta_exponent : float
         Change in aperiodic exponent to be applied.
         Positive is clockwise rotation (steepen).
         Negative is counterclockwise rotation (flatten).
@@ -84,22 +84,22 @@ def rotate_syn_spectrum(freqs, power_spectrum, delta, f_rotation, syn_params):
         Updated object storing the new parameter definitions.
     """
 
-    rotated_spectrum = rotate_spectrum(freqs, power_spectrum, delta, f_rotation)
-    delta_offset = calc_rot_offset(delta, f_rotation)
+    rotated_spectrum = rotate_spectrum(freqs, power_spectrum, delta_exponent, f_rotation)
+    delta_offset = calc_rot_offset(delta_exponent, f_rotation)
 
-    new_syn_params = update_syn_ap_params(syn_params, [delta_offset, delta])
+    new_syn_params = update_syn_ap_params(syn_params, [delta_offset, delta_exponent])
 
     return rotated_spectrum, new_syn_params
 
 
-def translate_syn_spectrum(power_spectrum, delta, syn_params):
+def translate_syn_spectrum(power_spectrum, delta_offset, syn_params):
     """Translate a spectrum, changing the offset value.
 
     Parameters
     ----------
     power_spectrum : 1d array
         Power values of the spectrum that is to be translated.
-    delta : float
+    delta_offset : float
         Amount to change the offset by.
         Positive is an upwards translation.
         Negative is a downwards translation.
@@ -114,18 +114,18 @@ def translate_syn_spectrum(power_spectrum, delta, syn_params):
         Updated object storing the new parameter definitions.
     """
 
-    translated_spectrum = translate_spectrum(power_spectrum, delta)
-    new_syn_params = update_syn_ap_params(syn_params, delta, 'offset')
+    translated_spectrum = translate_spectrum(power_spectrum, delta_offset)
+    new_syn_params = update_syn_ap_params(syn_params, delta_offset, 'offset')
 
     return translated_spectrum, new_syn_params
 
 
-def calc_rot_offset(delta, f_rotation):
+def calc_rot_offset(delta_exponent, f_rotation):
     """Calculate the change in offset from a given rotation.
 
     Parameters
     ----------
-    delta : float
+    delta_exponent : float
         Change in aperiodic exponent to be applied.
     f_rotation : float
         Frequency value, in Hz, about which rotation is applied, at which power is unchanged.
@@ -136,4 +136,4 @@ def calc_rot_offset(delta, f_rotation):
         The amount the offset will change for the specified exponent change.
     """
 
-    return -np.log10(f_rotation) * -delta
+    return -np.log10(f_rotation) * -delta_exponent

--- a/fooof/synth/transform.py
+++ b/fooof/synth/transform.py
@@ -18,8 +18,8 @@ def rotate_spectrum(freqs, power_spectrum, delta, f_rotation):
         Power values of the spectrum that is to be rotated.
     delta : float
         Change in aperiodic exponent to be applied.
-        Positive is counterclockwise rotation (flatten).
-        Negative is clockwise rotation (steepen).
+        Positive is clockwise rotation (steepen).
+        Negative is counterclockwise rotation (flatten).
     f_rotation : float
         Frequency value, in Hz, about which rotation is applied, at which power is unchanged.
 
@@ -29,7 +29,7 @@ def rotate_spectrum(freqs, power_spectrum, delta, f_rotation):
         Rotated power spectrum.
     """
 
-    mask = (np.abs(freqs) / f_rotation)**delta
+    mask = (np.abs(freqs) / f_rotation)**-delta
     rotated_spectrum = mask * power_spectrum
 
     return rotated_spectrum
@@ -69,8 +69,8 @@ def rotate_syn_spectrum(freqs, power_spectrum, delta, f_rotation, syn_params):
         Power values of the spectrum that is to be rotated.
     delta : float
         Change in aperiodic exponent to be applied.
-        Positive is counterclockwise rotation (flatten).
-        Negative is clockwise rotation (steepen).
+        Positive is clockwise rotation (steepen).
+        Negative is counterclockwise rotation (flatten).
     f_rotation : float
         Frequency value, in Hz, about which rotation is applied, at which power is unchanged.
     syn_params : SynParams object
@@ -136,4 +136,4 @@ def calc_rot_offset(delta, f_rotation):
         The amount the offset will change for the specified exponent change.
     """
 
-    return -np.log10(f_rotation) * delta
+    return -np.log10(f_rotation) * -delta

--- a/fooof/synth/transform.py
+++ b/fooof/synth/transform.py
@@ -101,7 +101,7 @@ def rotate_syn_spectrum(freqs, power_spectrum, delta_exponent, f_rotation, syn_p
     """
 
     rotated_spectrum = rotate_spectrum(freqs, power_spectrum, delta_exponent, f_rotation)
-    delta_offset = calc_rot_offset(delta_exponent, f_rotation)
+    delta_offset = calc_rotation_offset(delta_exponent, f_rotation)
 
     new_syn_params = update_syn_ap_params(syn_params, [delta_offset, delta_exponent])
 
@@ -136,7 +136,7 @@ def translate_syn_spectrum(power_spectrum, delta_offset, syn_params):
     return translated_spectrum, new_syn_params
 
 
-def calc_rot_offset(delta_exponent, f_rotation):
+def calc_rotation_offset(delta_exponent, f_rotation):
     """Calculate the change in offset from a given rotation.
 
     Parameters

--- a/fooof/synth/transform.py
+++ b/fooof/synth/transform.py
@@ -44,3 +44,26 @@ def rotate_spectrum(freqs, power_spectrum, delta_f, f_rotation):
     rotated_spectrum = f_mask * power_spectrum
 
     return rotated_spectrum
+
+
+def translate_spectrum(power_spectrum, delta):
+    """Translate a spectrum, changing the offset value.
+
+    Parameters
+    ----------
+    power_spectrum : 1d array
+        Power values of the spectrum that is to be translated.
+    delta : float
+        Amount to change the offset by.
+        Positive is an upwards translation.
+        Negative is a downwards translation.
+
+    Returns
+    -------
+    translated_spectrum : 1d array
+        Translated power spectrum.
+    """
+
+    translated_spectrum = np.power(10, delta, dtype='float') * power_spectrum
+
+    return translated_spectrum

--- a/fooof/synth/transform.py
+++ b/fooof/synth/transform.py
@@ -27,6 +27,14 @@ def rotate_spectrum(freqs, power_spectrum, delta_exponent, f_rotation):
     -------
     rotated_spectrum : 1d array
         Rotated power spectrum.
+
+    Notes
+    -----
+    Warning: This function should only be applied to spectra without a knee.
+    If using simulated data, this is spectra created in 'fixed' mode.
+    This is because the rotation applied will is inconsistent with
+    the formulation of knee spectra, and will change them in an
+    unspecified way, not just limited to doing the rotation.
     """
 
     mask = (np.abs(freqs) / f_rotation)**-delta_exponent
@@ -82,6 +90,14 @@ def rotate_syn_spectrum(freqs, power_spectrum, delta_exponent, f_rotation, syn_p
         Rotated power spectrum.
     new_syn_params : SynParams object
         Updated object storing the new parameter definitions.
+
+    Notes
+    -----
+    Warning: This function should only be applied to spectra without a knee.
+    If using simulated data, this is spectra created in 'fixed' mode.
+    This is because the rotation applied will is inconsistent with
+    the formulation of knee spectra, and will change them in an
+    unspecified way, not just limited to doing the rotation.
     """
 
     rotated_spectrum = rotate_spectrum(freqs, power_spectrum, delta_exponent, f_rotation)

--- a/fooof/synth/transform.py
+++ b/fooof/synth/transform.py
@@ -115,7 +115,7 @@ def translate_syn_spectrum(power_spectrum, delta, syn_params):
     """
 
     translated_spectrum = translate_spectrum(power_spectrum, delta)
-    new_syn_params = update_syn_ap_params(syn_params, delta, 'intercept')
+    new_syn_params = update_syn_ap_params(syn_params, delta, 'offset')
 
     return translated_spectrum, new_syn_params
 

--- a/fooof/synth/transform.py
+++ b/fooof/synth/transform.py
@@ -5,7 +5,7 @@ import numpy as np
 ###################################################################################################
 ###################################################################################################
 
-def rotate_spectrum(freqs, power_spectrum, delta_f, f_rotation):
+def rotate_spectrum(freqs, power_spectrum, delta, f_rotation):
     """Rotate a power spectrum about a frequency point, changing the power law exponent.
 
     Parameters
@@ -14,7 +14,7 @@ def rotate_spectrum(freqs, power_spectrum, delta_f, f_rotation):
         Frequency axis of input power spectrum, in Hz.
     power_spectrum : 1d array
         Power values of the spectrum that is to be rotated.
-    delta_f : float
+    delta : float
         Change in power law exponent to be applied.
         Positive is counterclockwise rotation (flatten).
         Negative is clockwise rotation (steepen).
@@ -33,7 +33,7 @@ def rotate_spectrum(freqs, power_spectrum, delta_f, f_rotation):
 
     f_mask = np.zeros_like(freqs)
 
-    f_mask = 10**(np.log10(np.abs(freqs)) * (delta_f))
+    f_mask = 10**(np.log10(np.abs(freqs)) * (delta))
 
     # If starting freq is 0Hz, default power at 0Hz to keep same value because log will return inf.
     if freqs[0] == 0.:

--- a/fooof/tests/test_fit.py
+++ b/fooof/tests/test_fit.py
@@ -29,9 +29,9 @@ def test_fooof_fit_nk():
     """Test FOOOF fit, no knee."""
 
     bgp = [50, 2]
-    gauss_params = [10, 0.5, 2, 20, 0.3, 4]
+    gaussian_params = [10, 0.5, 2, 20, 0.3, 4]
 
-    xs, ys = gen_power_spectrum([3, 50], bgp, gauss_params)
+    xs, ys = gen_power_spectrum([3, 50], bgp, gaussian_params)
 
     tfm = FOOOF()
     tfm.fit(xs, ys)
@@ -40,16 +40,16 @@ def test_fooof_fit_nk():
     assert np.all(np.isclose(bgp, tfm.aperiodic_params_, [0.5, 0.1]))
 
     # Check model results - gaussian parameters
-    for ii, gauss in enumerate(group_three(gauss_params)):
+    for ii, gauss in enumerate(group_three(gaussian_params)):
         assert np.all(np.isclose(gauss, tfm._gaussian_params[ii], [2.0, 0.5, 1.0]))
 
 def test_fooof_fit_knee():
     """Test FOOOF fit, with a knee."""
 
     bgp = [50, 2, 1]
-    gauss_params = [10, 0.5, 2, 20, 0.3, 4]
+    gaussian_params = [10, 0.5, 2, 20, 0.3, 4]
 
-    xs, ys = gen_power_spectrum([3, 50], bgp, gauss_params)
+    xs, ys = gen_power_spectrum([3, 50], bgp, gaussian_params)
 
     tfm = FOOOF(aperiodic_mode='knee')
     tfm.fit(xs, ys)

--- a/fooof/tests/test_group.py
+++ b/fooof/tests/test_group.py
@@ -87,7 +87,7 @@ def test_get_all_data(tfg):
         assert np.any(tfg.get_all_data(dname))
 
         if dname == 'aperiodic_params':
-            for dtype in ['intercept', 'exponent']:
+            for dtype in ['offset', 'exponent']:
                 assert np.any(tfg.get_all_data(dname, dtype))
 
         if dname == 'peak_params':

--- a/fooof/tests/test_synth_gen.py
+++ b/fooof/tests/test_synth_gen.py
@@ -24,9 +24,9 @@ def test_gen_power_spectrum():
 
     freq_range = [3, 50]
     bgp = [50, 2]
-    gauss_params = [10, 0.5, 2, 20, 0.3, 4]
+    gaussian_params = [10, 0.5, 2, 20, 0.3, 4]
 
-    xs, ys = gen_power_spectrum(freq_range, bgp, gauss_params)
+    xs, ys = gen_power_spectrum(freq_range, bgp, gaussian_params)
 
     assert np.all(xs)
     assert np.all(ys)
@@ -74,9 +74,9 @@ def test_gen_aperiodic():
 def test_gen_peaks():
 
     xs = gen_freqs([3, 50], 0.5)
-    gauss_params = [10, 2, 1]
+    gaussian_params = [10, 2, 1]
 
-    peaks = gen_peaks(xs, gauss_params)
+    peaks = gen_peaks(xs, gaussian_params)
 
     assert np.all(np.invert(np.isnan(peaks)))
 
@@ -85,9 +85,9 @@ def test_gen_power_values():
     xs = gen_freqs([3, 50], 0.5)
 
     bg_params = [50, 2]
-    gauss_params = [10, 2, 1]
+    gaussian_params = [10, 2, 1]
     nlv = 0.1
 
-    ys = gen_power_vals(xs, bg_params, gauss_params, nlv)
+    ys = gen_power_vals(xs, bg_params, gaussian_params, nlv)
 
     assert np.all(ys)

--- a/fooof/tests/test_synth_params.py
+++ b/fooof/tests/test_synth_params.py
@@ -20,7 +20,7 @@ def test_update_syn_ap_params():
     assert new_syn_params.aperiodic_params == [1, 2]
 
     # Check updating of multiple specified parameters
-    new_syn_params = update_syn_ap_params(syn_params, [1, 1], ['intercept', 'exponent'])
+    new_syn_params = update_syn_ap_params(syn_params, [1, 1], ['offset', 'exponent'])
     assert new_syn_params.aperiodic_params == [2, 2]
 
     # Check updating of all parameters

--- a/fooof/tests/test_synth_params.py
+++ b/fooof/tests/test_synth_params.py
@@ -1,9 +1,35 @@
-"""   """
+"""Test functions for FOOOF synth.params."""
+
+from py.test import raises
 
 from fooof.synth.params import *
 
 ###################################################################################################
 ###################################################################################################
+
+def test_syn_params():
+
+    assert SynParams([1, 1], [10, 1, 1], 0.05)
+
+def test_update_syn_ap_params():
+
+    syn_params = SynParams([1, 1], [10, 1, 1], 0.05)
+
+    # Check updating of a single specified parameter
+    new_syn_params = update_syn_ap_params(syn_params, 1, 'exponent')
+    assert new_syn_params.aperiodic_params == [1, 2]
+
+    # Check updating of multiple specified parameters
+    new_syn_params = update_syn_ap_params(syn_params, [1, 1], ['intercept', 'exponent'])
+    assert new_syn_params.aperiodic_params == [2, 2]
+
+    # Check updating of all parameters
+    new_syn_params = update_syn_ap_params(syn_params, [1, 1])
+    assert new_syn_params.aperiodic_params == [2, 2]
+
+    # Check error with invalid overwrite
+    with raises(ValueError):
+        new_syn_params = update_syn_ap_params(syn_params, [1, 1, 1])
 
 def test_stepper():
 

--- a/fooof/tests/test_synth_transform.py
+++ b/fooof/tests/test_synth_transform.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from fooof.synth.gen import gen_power_spectrum
+from fooof.synth.params import SynParams
 from fooof.synth.transform import *
 
 ###################################################################################################
@@ -33,3 +34,26 @@ def test_translate_spectrum():
     # Check that 0 translation returns the same spectrum
     translated_spectrum = translate_spectrum(spectrum, delta=0.)
     assert np.all(translated_spectrum == spectrum)
+
+def test_rotate_syn_spectrum():
+
+    syn_params = SynParams([1, 1], [10, 0.5, 1], 0)
+    freqs, spectrum = gen_power_spectrum([3, 40], *syn_params)
+
+    rotated_spectrum, new_syn_params = rotate_syn_spectrum(freqs, spectrum, 0.5, 20, syn_params)
+
+    assert not np.all(rotated_spectrum == spectrum)
+    assert new_syn_params.aperiodic_params[1] == 1.5
+
+def test_translate_syn_spectrum():
+
+    syn_params = SynParams([1, 1], [10, 0.5, 1], 0)
+    freqs, spectrum = gen_power_spectrum([3, 40], *syn_params)
+
+    translated_spectrum, new_syn_params = translate_syn_spectrum(spectrum, 0.5, syn_params)
+    assert not np.all(translated_spectrum == spectrum)
+    assert new_syn_params.aperiodic_params[0] == 1.5
+
+def cal_rot_offset():
+
+    assert calc_rot_offset(20, 0.5)

--- a/fooof/tests/test_synth_transform.py
+++ b/fooof/tests/test_synth_transform.py
@@ -20,3 +20,16 @@ def test_rotate_spectrum():
     # Check that 0 rotation returns the same spectrum
     rotated_spectrum = rotate_spectrum(freqs, spectrum, delta_f=0., f_rotation=25.)
     assert np.all(rotated_spectrum == spectrum)
+
+def test_translate_spectrum():
+
+    # Create a spectrum to use for test translation
+    freqs, spectrum = gen_power_spectrum([1, 100], [1, 1], [])
+
+    # Check that translation transforms the power spectrum
+    translated_spectrum = translate_spectrum(spectrum, delta=1.)
+    assert not np.all(translated_spectrum == spectrum)
+
+    # Check that 0 translation returns the same spectrum
+    translated_spectrum = translate_spectrum(spectrum, delta=0.)
+    assert np.all(translated_spectrum == spectrum)

--- a/fooof/tests/test_synth_transform.py
+++ b/fooof/tests/test_synth_transform.py
@@ -14,11 +14,11 @@ def test_rotate_spectrum():
     freqs, spectrum = gen_power_spectrum([1, 100], [1, 1], [])
 
     # Check that rotation transforms the power spectrum
-    rotated_spectrum = rotate_spectrum(freqs, spectrum, delta_f=0.5, f_rotation=25.)
+    rotated_spectrum = rotate_spectrum(freqs, spectrum, delta=0.5, f_rotation=25.)
     assert not np.all(rotated_spectrum == spectrum)
 
     # Check that 0 rotation returns the same spectrum
-    rotated_spectrum = rotate_spectrum(freqs, spectrum, delta_f=0., f_rotation=25.)
+    rotated_spectrum = rotate_spectrum(freqs, spectrum, delta=0., f_rotation=25.)
     assert np.all(rotated_spectrum == spectrum)
 
 def test_translate_spectrum():

--- a/fooof/tests/test_synth_transform.py
+++ b/fooof/tests/test_synth_transform.py
@@ -54,6 +54,6 @@ def test_translate_syn_spectrum():
     assert not np.all(translated_spectrum == spectrum)
     assert new_syn_params.aperiodic_params[0] == 1.5
 
-def cal_rot_offset():
+def cal_rotation_offset():
 
-    assert calc_rot_offset(20, 0.5)
+    assert calc_rotation_offset(20, 0.5)

--- a/fooof/tests/test_synth_transform.py
+++ b/fooof/tests/test_synth_transform.py
@@ -15,11 +15,11 @@ def test_rotate_spectrum():
     freqs, spectrum = gen_power_spectrum([1, 100], [1, 1], [])
 
     # Check that rotation transforms the power spectrum
-    rotated_spectrum = rotate_spectrum(freqs, spectrum, delta=0.5, f_rotation=25.)
+    rotated_spectrum = rotate_spectrum(freqs, spectrum, delta_exponent=0.5, f_rotation=25.)
     assert not np.all(rotated_spectrum == spectrum)
 
     # Check that 0 rotation returns the same spectrum
-    rotated_spectrum = rotate_spectrum(freqs, spectrum, delta=0., f_rotation=25.)
+    rotated_spectrum = rotate_spectrum(freqs, spectrum, delta_exponent=0., f_rotation=25.)
     assert np.all(rotated_spectrum == spectrum)
 
 def test_translate_spectrum():
@@ -28,11 +28,11 @@ def test_translate_spectrum():
     freqs, spectrum = gen_power_spectrum([1, 100], [1, 1], [])
 
     # Check that translation transforms the power spectrum
-    translated_spectrum = translate_spectrum(spectrum, delta=1.)
+    translated_spectrum = translate_spectrum(spectrum, delta_offset=1.)
     assert not np.all(translated_spectrum == spectrum)
 
     # Check that 0 translation returns the same spectrum
-    translated_spectrum = translate_spectrum(spectrum, delta=0.)
+    translated_spectrum = translate_spectrum(spectrum, delta_offset=0.)
     assert np.all(translated_spectrum == spectrum)
 
 def test_rotate_syn_spectrum():

--- a/fooof/tests/utils.py
+++ b/fooof/tests/utils.py
@@ -16,9 +16,9 @@ def get_tfm():
 
     freq_range = [3, 50]
     bg_params = [50, 2]
-    gauss_params = [10, 0.5, 2, 20, 0.3, 4]
+    gaussian_params = [10, 0.5, 2, 20, 0.3, 4]
 
-    xs, ys = gen_power_spectrum(freq_range, bg_params, gauss_params)
+    xs, ys = gen_power_spectrum(freq_range, bg_params, gaussian_params)
 
     tfm = FOOOF()
     tfm.fit(xs, ys)


### PR DESCRIPTION
Responds to / related to #109

This is a primarily a refactor and extension of fooof.synth.transform. A couple other small updates for naming consistency (using the same convention for gauss*_params between SynParams & gen, and standardizing on calling the ap param 'offset', instead of 'intercept'). 

Notes / comments (mostly Qs for @rdgao):
- Do we know how the knee behaves with these kind of transforms? From quick tests, it appears that, rotating the spectrum does not preserve the knee (which, I think, is to be expected). I'm guessing we can work through figuring out how it does so - though perhaps for now we can just add a note that this is only designed for rotating 'fixed' spectra? (I don't currently need the knee case). 
- I switched the convention for the direction of rotation, so now positive value steepens, etc (this, I think, is consistent with FOOOFs conventions of using positive exponents). This seems like the more obvious way to do it (given how FOOOF sets up the equations), since a delta of + 0.2 can be interpreted as "OG-val + 0.2", and -0.2 as "OG-val - 0.2", etc. I originally hit this point based on an unexpected sign flip in when updating parameter values.  In the code, this meant adding a negative sign in rotate_spectrum (and calc_rot_offset). Do you have any reason to disprefer doing this? I can switch it all back if theres a reason this update doesn't make sense somehow. 
- rotate_spectrum is now quite different from the original function in NDSP. In terms of scoping, I would probably suggest removing that function from NDSP? But if we really want to keep it, we could update it there, similarly to here. 

ToDo: we should add some notes on the derivations that perform these transformations. I'm gonna leave that to @rdgao if possible :). 

@ArcadeShrimp : as a user of this kind of functionality, do you want to eyeball this and check that it makes sense to you? You don't have to worry about the implementation details / math - but just check if this seems useful from a user-facing perspective. 

Note that an open idea in #109 is also to have an option to simulate spectra with specified rotation points directly in the gen_* functions. This is doable (I think, in a clean way) - but not added, and could be. 
^Edit: this idea seems to get a little complicated in terms of dealing with also with generating knee spectra - so will pause on that idea until we figure that part out. 