### PR TITLE
FIX: Fix typos in the documentation site.

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -102,8 +102,9 @@ From the physics perspective, '1/f' activity is sometimes referred to as 'noise'
 as shorthand for 'statistical noise' or `coloured noise <https://en.wikipedia.org/wiki/Colors_of_noise>`_.
 As well as not necessarily meeting technical definitions, referring to aperiodic neural activity
 as noise in this way is also different to how the terms 'signal' & 'noise' are typically
-used in neuroscience, in terms of referring to a signal of interest as unwanted or artifactual
-activity. We consider that the aperiodic could be the signal of interest for some investigations.
+used in neuroscience. In neuroscience, the terms 'signal' & 'noise' are typically used
+to refer to data of interest, and unwanted or artefactual data, respectively.
+We consider that the aperiodic could be the signal of interest for some investigations.
 Therefore, we have moved away from this term so as not to imply it is either strictly statistical
 noise, nor is it merely unwanted 'noise' in the recording.
 
@@ -139,8 +140,8 @@ above the power as expected by the aperiodic activity. In this situation, one sh
 wary of interpreting activity at this frequency, as it is most likely reflects aperiodic
 activity.
 
-However, we cannot prove a negative, and the absence of a detected peak does
-therefore imply that there must be no periodic activity at that frequency band. There could
+However, we cannot prove a negative, and so the absence of a detected peak does not
+imply that there is definitively no periodic activity at that particular frequency. There could
 be very low power periodic activity, and/or periodic activity that is variable through time
 (bursty) such as to not display a prominent peak across the analyzed time sample.
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -28,7 +28,7 @@ putative functional roles.
 
 FOOOF operates on frequency representation of neurophysiological times series (power spectra).
 At it's core, FOOOF is a fitting procedure to measure these two components - the periodic and
-aperiodic components - in power spectra. The full model fit consists of a parameterizing of these
+aperiodic components - in power spectra. The full model fit consists of parameterizing these
 aperiodic and periodic components, as well as a full (combined) model fit of the whole
 power spectrum.
 
@@ -79,7 +79,7 @@ and systematically varies both within [1_] and between [2_] subjects.
 
 The dynamic properties of the aperiodic activity means that even if periodic activity
 is still the focus of the analysis, quantification of such data must explicitly account
-for aperiodic activity to appropriately measure what components of the data are actually
+for aperiodic activity to appropriately measure which components of the data are actually
 changing.
 
 In addition, aperiodic components of neural signals may be important and interesting
@@ -101,8 +101,8 @@ frequency ranges, it is not truly '1/f' across all frequencies.
 From the physics perspective, '1/f' activity is sometimes referred to as 'noise',
 as shorthand for 'statistical noise' or `coloured noise <https://en.wikipedia.org/wiki/Colors_of_noise>`_.
 As well as not necessarily meeting technical definitions, referring to aperiodic neural activity
-as noise in this way is also different however to how the terms 'signal' & 'noise' are typically
-used in neuroscience, in terms of referring to a signal of interest and unwanted or artifactual
+as noise in this way is also different to how the terms 'signal' & 'noise' are typically
+used in neuroscience, in terms of referring to a signal of interest as unwanted or artifactual
 activity. We consider that the aperiodic could be the signal of interest for some investigations.
 Therefore, we have moved away from this term so as not to imply it is either strictly statistical
 noise, nor is it merely unwanted 'noise' in the recording.
@@ -136,10 +136,10 @@ If a peak is not detected, in the power spectrum, within a given frequency band,
 consistent with there being no periodic activity at that frequency. Without a detected peak,
 we argue that there is no evidence of periodic activity, at that frequency, over and
 above the power as expected by the aperiodic activity. In this situation, one should be very
-wary of interpreting activity at this frequency, as it is most likely to reflect aperiodic
+wary of interpreting activity at this frequency, as it is most likely reflects aperiodic
 activity.
 
-However, we can, of course not prove a negative, and the absence of a detected peak does
+However, we cannot prove a negative, and the absence of a detected peak does
 therefore imply that there must be no periodic activity at that frequency band. There could
 be very low power periodic activity, and/or periodic activity that is variable through time
 (bursty) such as to not display a prominent peak across the analyzed time sample.
@@ -215,12 +215,12 @@ I'm interested in a particular oscillation band, should I fit a small range?
 Generally, no, it is better to always try and fit a broad range, rather than to fit a small
 frequency range, even if one is interested in a specific oscillation band in particular.
 
-This is because the if a small frequency range is used, it becomes much more difficult to
+This is because if a small frequency range is used, it becomes much more difficult to
 estimate the aperiodic component of the data, and without a good estimate of the aperiodic
 component, it can also be more difficult to effectively estimate the periodic components.
 
 Therefore, if one is interested in, for example, alpha oscillations (approximately 7-14 Hz),
-the we still recommend fitting a broad range (for example, 3-40 Hz), and then extracting the
+then we still recommend fitting a broad range (for example, 3-40 Hz), and then extracting the
 alpha oscillations post-hoc. There are utilities in fooof.analysis to extract oscillations
 from particular bands, and examples of this on the examples page.
 

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -10,7 +10,7 @@ A glossary of terms used in the module, with a description of how they are used,
         We use `FOOOF` to refer to either the current module, or to `FOOOF` objects.
 
     Field Data
-        'Field data' is used as a catch-all for the relevant types of data that the power spectrum model can be applied to. This includes recordings of electrophysiological or magnetophysiological 'fields', meaning recordings modalities such as electroencephalography (EEG), magnetoencephalography (MEG), electrocorticography (ECoG), and local field potential (LFP) data.
+        'Field data' is used as a catch-all for the relevant types of data that the power spectrum model can be applied to. This includes recordings of electrophysiological or magnetophysiological 'fields', meaning recording modalities such as electroencephalography (EEG), magnetoencephalography (MEG), electrocorticography (ECoG), and local field potential (LFP) data.
 
     Power Spectrum
         A power spectrum (short for power spectral density) describes the distribution of power across frequencies.
@@ -20,11 +20,11 @@ A glossary of terms used in the module, with a description of how they are used,
         This module implements a particular power spectrum model, whereby we conceptualize and describe mathematically a model that considers power spectra as a combination of periodic and aperiodic components, each of which can be described by a set of model parameters.
 
     FOOOF Objects
-        This module is object is object-oriented, whereby the algorithm to parameterize neural power spectra is implemented in Python objects. We refer to those objects as 'FOOOF objects'.
+        This module is object-oriented, whereby the algorithm to parameterize neural power spectra is implemented in Python objects. We refer to those objects as 'FOOOF objects'.
 
     Component
         By 'component' we mean a part, or aspect, of the data.
-        Different components of the data are consired to be separate aspects of, or entities in, the data, (though they need not be be completely independent).
+        Different components of the data are considered to be separate aspects of, or entities in, the data, (though they need not be be completely independent).
 
     Parameters
         We use the term 'parameters' to describe the parameters of the model, meaning the values in the model that are fit to the data. These model parameters are the results of the model fitting.
@@ -36,7 +36,7 @@ A glossary of terms used in the module, with a description of how they are used,
         Periodic (or 'rhythmic') component(s) of the data, that reflect putative oscillations.
 
     Peaks
-        Parts of the power spectrum that are identified to have power over and above the aperiodic component, and are thus modeled as 'peaks', reflecting putative oscillations. The set of identified peaks are the periodic component(s) of the data. The peaks are described by the peak parameter: center frequency (CF), power (PW), and bandwidth (bw).
+        Parts of the power spectrum that are identified to have power over and above the aperiodic component, and are thus modeled as 'peaks', reflecting putative oscillations. The set of identified peaks are the periodic component(s) of the data. The peaks are described by the peak parameters: center frequency (CF), power (PW), and bandwidth (bw).
 
     Aperiodic
         Aperiodic (or 'arrhythmic') components of the data.
@@ -66,7 +66,7 @@ A glossary of terms used in the module, with a description of how they are used,
         The OFF is an aperiodic parameter, as part of the aperiodic component of the data.
 
     Knee (KNE)
-        An optional parameter of the aperiodic fit that relates to frequency locations at where there is a 'bend' or a 'knee', when plotted in log-log space, in the 1/f-like aperiodic activity.
+        An optional parameter of the aperiodic fit that relates to frequency locations where there is a 'bend' or a 'knee', when plotted in log-log space, in the 1/f-like aperiodic activity.
         The KNE is an aperiodic parameter, as part of the aperiodic component of the data.
 
     Exponent (EXP)

--- a/examples/analyses/plot_mne_example.py
+++ b/examples/analyses/plot_mne_example.py
@@ -224,7 +224,7 @@ for ind, (label, band_def) in enumerate(bands):
 #
 # You might notice that the topographies of some of the bands look a little 'patchy'.
 # This is because we are setting any channels for which we did not find a peak as zero
-# with our `check_nan` approach. Note that is also a single subject analysis.
+# with our `check_nan` approach. Note this is also a single subject analysis.
 #
 
 ###################################################################################################
@@ -298,7 +298,4 @@ plot_spectrum(fg.freqs, fg.get_fooof(np.argmax(exps)).power_spectrum,
 #
 
 ###################################################################################################
-#
-# Sphinx settings:
-# sphinx_gallery_thumbnail_number = 2
 #

--- a/examples/manage/plot_fit_fooof_3d.py
+++ b/examples/manage/plot_fit_fooof_3d.py
@@ -38,7 +38,7 @@ Fitting power spectrum models across 3D arrays of power spectra.
 # explore how to fit, manage, and organize this data.
 #
 # A reminder that no matter how the data is organized, it's always the exact same model
-# that is fit, that is the on defined in the FOOOF object. All other objects or organizations
+# that is fit, that is the one defined in the FOOOF object. All other objects or organizations
 # use this same code to do the fitting. For example, the FOOOFGroup object inherits from the
 # FOOOF, and calls the same underlying fit function.
 #
@@ -209,10 +209,10 @@ for ind, fg in enumerate(fgs):
 #
 # When running analyses like this, you may start to have many :class:`~fooof.FOOOF` objects.
 #
-# For example, you may want to save them out, reload them as needed, analyze
-# results from each :class:`~fooof.FOOOF` or :class:`~fooof.FOOOFGroup` object,
-# and also manipulate the objects by, for example, combining model results across
-# objects to check overall model fit properties.
+# For example, you may want to save them out, reload them as needed, and analyze
+# results from each :class:`~fooof.FOOOF` or :class:`~fooof.FOOOFGroup` object.
+# You may also manipulate the objects by, for example, combining model results
+# across objects to check overall model fit properties.
 #
 # Here, we will continue with a quick example of saving, loading and then combining
 # FOOOF objects. Note that a broader exploration of managing different FOOOF objects

--- a/examples/manage/plot_manipulating_fooofs.py
+++ b/examples/manage/plot_manipulating_fooofs.py
@@ -92,7 +92,7 @@ print('Number of model fits: ', len(fg))
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Note that these functions that manipulate FOOOF objects typically do more than just
-# copying result data - they also check and manage settings and meta-data of objects.
+# copy results data - they also check and manage settings and meta-data of objects.
 #
 # For example, combining FOOOF objects returns a new FOOOFGroup object with the same settings.
 #

--- a/examples/plots/plot_model_components.py
+++ b/examples/plots/plot_model_components.py
@@ -30,7 +30,7 @@ from fooof.plts.aperiodic import plot_aperiodic_params, plot_aperiodic_fits
 # model parameters and components from fitting power spectrum models.
 #
 # To do so, we will consider a hypothetical experiment in which we are compare power
-# spectrum models between two groups of participants, and so want to visualize differences
+# spectrum models between two groups of participants, and so we want to visualize differences
 # between the groups. For simplicity, we will consider that we have one 'grand average'
 # power spectrum per subject, which we can compare and visualize.
 #

--- a/examples/plots/plot_power_spectra.py
+++ b/examples/plots/plot_power_spectra.py
@@ -22,7 +22,7 @@ from fooof.sim.params import param_iter, Stepper
 # Plotting Power Spectra
 # ----------------------
 #
-# The module also includes a plotting sub-module that includes a several plotting
+# The module also includes a plotting sub-module that includes several plotting
 # options for visualizing power spectra.
 #
 # These plot functions overlap with what is accessible directly through the FOOOF objects,
@@ -97,7 +97,7 @@ plot_spectra(freqs, [powers1, powers2], log_freqs=True, log_powers=True, labels=
 # for example, when examining power in particular frequency regions.
 #
 # The :func:`~fooof.plts.spectra.plot_spectrum_shading` function takes in a power spectrum
-# and one or more shade regions, and plot the power spectrum with the indicated region shaded.
+# and one or more shaded regions, and plot the power spectrum with the indicated region shaded.
 #
 # The same can be done for multiple power spectra with
 # :func:`~fooof.plts.spectra.plot_spectra_shading`.
@@ -122,7 +122,7 @@ plot_spectra_shading(freqs, [powers1, powers2], [[4, 8], [20, 30]],
 # Put it all together
 # -------------------
 #
-# Finally, we can put all these plotting tool together.
+# Finally, we can put all these plotting tools together.
 #
 # To do so, note also that all plot functions also take in an optional `ax` argument
 # that can specify an axes to plot on. This can be used to place plots in multi-axes

--- a/examples/sims/plot_sim_params.py
+++ b/examples/sims/plot_sim_params.py
@@ -74,7 +74,7 @@ freqs, powers = gen_power_spectrum(freq_range, *cur_params)
 # These functions include:
 #
 # - :func:`~fooof.sim.params.param_sampler` which can be used to sample
-#   parameters from a possible options
+#   parameters from possible options
 # - :func:`~fooof.sim.params.param_iter` which can be used to iterate across
 #   parameter ranges
 # - :func:`~fooof.sim.params.param_jitter` which can be used to add some 'jitter'

--- a/examples/sims/plot_transforms.py
+++ b/examples/sims/plot_transforms.py
@@ -132,7 +132,7 @@ plot_spectra(freqs, [powers, t_powers], log_freqs=True, log_powers=True)
 #
 # If you are transforming simulated spectra, it can be useful to keep track of these changes.
 #
-# To do so, there are also the function :func:`~fooof.sim.transform.rotate_sim_spectrum`
+# To do so, there are also the functions :func:`~fooof.sim.transform.rotate_sim_spectrum`
 # and :func:`~fooof.sim.transform.translate_sim_spectrum`, which work the same as what
 # we've seen so far, with the addition that they take in a :obj:`~fooof.data.data.SimParams`
 # object, and update and return a new :obj:`~fooof.data.data.SimParams` object that tracks

--- a/fooof/analysis/periodic.py
+++ b/fooof/analysis/periodic.py
@@ -46,7 +46,7 @@ def get_band_peak_fg(fg, band, threshold=None, thresh_param='PW', attribute='pea
         Object to extract peak data from.
     band : tuple of (float, float)
         Frequency range for the band of interest.
-        Defind as: (lower_frequency_bound, upper_frequency_bound).
+        Defined as: (lower_frequency_bound, upper_frequency_bound).
     threshold : float
         A minimum threshold value to apply.
     thresh_param : {'PW', 'BW'}
@@ -94,7 +94,7 @@ def get_band_peak_group(peak_params, band, n_fits, threshold=None, thresh_param=
 
     * To do so, this function necessarily extracts and returns one peak per model fit.
 
-    If, instead, you with to extract all peaks within a band, per model fit, you can do:
+    If, instead, you wish to extract all peaks within a band, per model fit, you can do:
 
     >>> peaks = np.empty((0, 3))
     >>> for f_res in fg:

--- a/fooof/sim/transform.py
+++ b/fooof/sim/transform.py
@@ -41,7 +41,7 @@ def rotate_spectrum(freqs, power_spectrum, delta_exponent, f_rotation):
     - unity at the rotation frequency
     - has an exponent of the desired delta exponent
 
-    This mask, when applied to a spectrum, as 'spectrum * mask should result in:
+    This mask, when applied to a spectrum as 'spectrum * mask', should result in:
 
     - rotated_spectrum = 1/f^(original_exponent + delta_exponent), where
     - spectrum[rotation_frequency] == rotated spectrum[rotation_frequency]

--- a/fooof/utils/data.py
+++ b/fooof/utils/data.py
@@ -79,7 +79,7 @@ def interpolate_spectrum(freqs, powers, interp_range, buffer=3):
 
     To be more robust to noise, this approach takes a number of samples on either
     side of the interpolation range (the number of which is controlled by `buffer`)
-    and averages these points to us to linearly interpolate between them.
+    and averages these points to linearly interpolate between them.
     Setting `buffer=1` is equivalent to a linear interpolation between
     the points adjacent to the interpolation range.
 

--- a/motivations/concepts/plot_DoYouEvenOscillate.py
+++ b/motivations/concepts/plot_DoYouEvenOscillate.py
@@ -29,7 +29,7 @@ Exploring the rhythmicity of time series and their frequency representations.
 # Fourier transform and other similar measures, to compute frequency representations
 # of any time series data.
 #
-# However, just because a signal _can_ be represented by sinusoids does not mean that any
+# However, just because a signal can be represented by sinusoids does not mean that any
 # given signal, or any given aspect of a signal, for which a power spectrum can be computed
 # should be conceptualized as being comprised of rhythmic components.
 #
@@ -116,7 +116,7 @@ plot_power_spectra(freqs, powers)
 #
 # In this case, and many like it, power across all frequencies is a representation of
 # transient (or aperiodic) activity in the time series. Broadly, when there are transients,
-# or aperiodic components, lots of sinusoids have to added together in order to represent
+# or aperiodic components, lots of sinusoids have to be added together in order to represent
 # aperiodic activity out of a basis set of periodic sine waves, and this is why such
 # signals typically look very broadband in the frequency domain.
 #

--- a/motivations/concepts/plot_IfYouFilterTheyWillCome.py
+++ b/motivations/concepts/plot_IfYouFilterTheyWillCome.py
@@ -19,7 +19,7 @@ Examining the results of filtering aperiodic signals.
 # entail any periodic activity, but it can look like periodic activity when applying
 # transforms such as narrow-band filters.
 #
-# In this notebook we will simulate purely aperiodic filters, and apply filters to
+# In this notebook we will simulate purely aperiodic signals, and apply filters to
 # them, to explore these ideas.
 #
 
@@ -104,7 +104,7 @@ for ax, (label, f_range) in zip(axes, bands):
 ###################################################################################################
 #
 # As we can see, filtering a signal with aperiodic activity into arbitrary
-# frequency ranges returns filtered signals that _look_ like rhythmic activity.
+# frequency ranges returns filtered signals that look like rhythmic activity.
 #
 # Also, because our simulated signal has some random variation, the filtered components
 # also exhibit some fluctuations.
@@ -202,7 +202,7 @@ plt.xlim(0, n_seconds); plt.ylim(-1, 1);
 # -----------
 #
 # Here we have seen that filtering signals to narrow band signals can return results
-# that reflect aperiodic activity and dynamics. We therefore suggest that
+# that reflect periodic activity and dynamics. We therefore suggest that
 # narrow band filtered signals should not be presumed to necessarily reflect periodic
 # activity. In order to ascertain whether narrow band frequency regions reflect
 # periodic and/or aperiodic activity and which aspects are changing in the data,

--- a/motivations/measurements/plot_BandByBand.py
+++ b/motivations/measurements/plot_BandByBand.py
@@ -51,7 +51,7 @@ from fooof.analysis import get_band_peak_fm
 # correlated changes in power across multiple distinct bands.
 #
 # An alternative hypothesis for what is changing is that this pattern of results could
-# be driven by changes or differences in the aperiodic component of the data. changes
+# be driven by changes or differences in the aperiodic component of the data. Changes
 # in aperiodic activity, when analyzed in a band-by-band manner, can look like correlated
 # changes across multiple bands.
 #
@@ -319,7 +319,7 @@ for label, definition in bands:
 # the frequency bands. However, the parameterized analysis reports no differences in
 # identified peaks.
 #
-# Note that when comparing peaks, 'nan' reflect thats there were no identified peaks to
+# Note that when comparing peaks, 'nan' reflects that there were no identified peaks to
 # compare, where are a zero value reflects that peaks were detected, but they did not differ.
 #
 # In this case, we know that the parameterization approach results in the correct

--- a/tutorials/plot_01-ModelDescription.py
+++ b/tutorials/plot_01-ModelDescription.py
@@ -61,7 +61,7 @@ fm2.fit(freqs2, powers2)
 # The goal of this module is to fit models to parameterize neural power spectra.
 #
 # One reason to do so is the idea that there are multiple distinct 'components' within
-# neural field data. The goal of the model is therefore to measure these different#
+# neural field data. The goal of the model is therefore to measure these different
 # 'components' of the data.
 #
 # By components, we mean that we are going to conceptualize neural field data as consisting
@@ -357,7 +357,4 @@ plot_annotated_model(fm2, plt_log=True)
 #
 
 ###################################################################################################
-#
-# Sphinx settings:
-# sphinx_gallery_thumbnail_number = 5
 #

--- a/tutorials/plot_02-FOOOF.py
+++ b/tutorials/plot_02-FOOOF.py
@@ -43,7 +43,7 @@ spectrum = load_fooof_data('spectrum.npy', folder='data')
 # the FOOOF module.
 #
 # The model is broadly agnostic to exactly how power spectra are computed. Common
-# methods, such as Welch's method, can be used to compute the spectrogram.
+# methods, such as Welch's method, can be used to compute the spectrum.
 #
 # If you need a module in Python that has functionality for computing power spectra, try
 # `NeuroDSP <https://neurodsp-tools.github.io/neurodsp/>`_

--- a/tutorials/plot_02-FOOOF.py
+++ b/tutorials/plot_02-FOOOF.py
@@ -43,7 +43,7 @@ spectrum = load_fooof_data('spectrum.npy', folder='data')
 # the FOOOF module.
 #
 # The model is broadly agnostic to exactly how power spectra are computed. Common
-# methods, such as using Welch's method to compute the spectrogram
+# methods, such as Welch's method, can be used to compute the spectrogram.
 #
 # If you need a module in Python that has functionality for computing power spectra, try
 # `NeuroDSP <https://neurodsp-tools.github.io/neurodsp/>`_

--- a/tutorials/plot_03-FOOOFAlgorithm.py
+++ b/tutorials/plot_03-FOOOFAlgorithm.py
@@ -239,7 +239,7 @@ fm.plot(plt_log)
 #
 # As you may have noticed through this tutorial, the :class:`~fooof.FOOOF` object keeps
 # track of some versions of the original data as well as individual model components fits,
-# as well as the final model fit that ultimate outcome of the fitting procedure.
+# as well as the final model fit, the ultimate outcome of the fitting procedure.
 #
 # These attributes in the FOOOF object are kept at the end of the fitting procedure.
 # Though they are primarily computed for internal use (hence being considered 'private'

--- a/tutorials/plot_05-AperiodicFitting.py
+++ b/tutorials/plot_05-AperiodicFitting.py
@@ -154,7 +154,7 @@ fm.report(freqs, spectrum, [2, 70], plt_log=True)
 # Conclusion
 # ----------
 #
-# Now that we have explored the :class:`~fooof.FOOOF` object, and different fitting
-# approaches for fitting the aperiodic component. Next up, we will continue be
-# introducing how to scale the fitting to apply across multiple power spectra.
+# We have now explored the :class:`~fooof.FOOOF` object, and different fitting
+# approaches for the aperiodic component. Next up, we will be introducing how
+# to scale the fitting to apply across multiple power spectra.
 #

--- a/tutorials/plot_06-FOOOFGroup.py
+++ b/tutorials/plot_06-FOOOFGroup.py
@@ -92,7 +92,7 @@ freqs, spectra = gen_group_power_spectra(n_spectra, f_range, ap_opts, gauss_opts
 # The main difference is that instead of running across a single power spectrum, it
 # operates across 2D matrices containing multiple power spectra.
 #
-# Note that by 'group' we mean merely to refer to a group of power-spectra,
+# Note that by 'group' we mean merely to refer to a group of power-spectra. We
 # are not using the term 'group' in terms of necessarily referring to multiple subjects
 # or any particular idea of what a 'group' may be. A group of power spectra could
 # be spectra from across channels, or across trials, or across subjects, or


### PR DESCRIPTION
This issue relates to #167, which is a review of the documentation site. 

Changes:
- fixes typos found in motivations, tutorials, examples, docstrings, and faq sections.