### PR TITLE
[ENH] Conda support added

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+# Conda-forge instructions:
+#   - Fork the feedstock repo (https://github.com/conda-forge/fooof-feedstock).
+#   - Update the meta.yaml file.
+#   - Make a pull request. Once merged, the package will be rebuilt on the conda-forge channel.
+
+# Anaconda is required to upload to Anaconda Cloud.
+if [[ $(which anaconda) == '' ]]; then
+    echo "Anaconda is not installed or not in \$PATH. Exiting."
+    exit 1
+fi
+
+# Install conda-build if not found.
+if [[ $(conda list | grep conda-build) == '' ]]; then
+    echo "Installing conda-build."
+    conda install conda-build
+fi
+
+# Install anaconda-client if not found.
+if [[ $(conda list | grep anaconda-client) == '' ]]; then
+    echo "Installing anaconda-client."
+    conda install anaconda-client
+fi
+
+# Build
+mkdir -p build
+echo "Building..."
+conda build fooof --output-folder=build >> build.log 2>&1
+build=$(conda build fooof --output-folder=build --output)
+
+# Upload. Note: this will prompt a username/password
+echo "Uploading to cloud..."
+anaconda upload --user fooof-tools $build
+
+echo -e "To install fooof with conda, run:\n\tconda install -c fooof-tools fooof"

--- a/conda/fooof/meta.yaml
+++ b/conda/fooof/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "fooof" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: af54117369204f8aec5b6b1551971bf634a2e7eab60ceb9e9d92811379a4d524
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.5
+    - pip
+  run:
+    - python >=3.5
+    - numpy
+    - scipy >=0.19.0
+
+test:
+  imports:
+    - fooof
+    - fooof.analysis
+    - fooof.bands
+    - fooof.core
+    - fooof.data
+    - fooof.objs
+    - fooof.plts
+    - fooof.sim
+    - fooof.tests
+    - fooof.tests.analysis
+    - fooof.tests.bands
+    - fooof.tests.core
+    - fooof.tests.data
+    - fooof.tests.objs
+    - fooof.tests.plts
+    - fooof.tests.sim
+    - fooof.tests.utils
+    - fooof.utils
+  requires:
+    - pytest
+
+about:
+  home: "https://github.com/fooof-tools/fooof"
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: "fitting oscillations & one-over f"
+  doc_url: https://fooof-tools.github.io/fooof/
+  dev_url: "https://github.com/fooof-tools/fooof"
+
+extra:
+  recipe-maintainers:
+    - ryanhammonds


### PR DESCRIPTION
This is the same as the ndsp conda PR. The build.sh script will push an anaconda build of the latest pypi release to our own channel (it has already been ran for the latest pypi release). A [conda-forge PR](https://github.com/conda-forge/staged-recipes/pull/12130) has been made using the meta.yaml file, to additionally support the conda-forge channel.