### PR TITLE
[ENH] Add `check_data` mode to deal with running with/without nan values

### DIFF
--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -445,7 +445,7 @@ class FOOOF():
             #   This serves as a catch all for curve_fits which will fail given NaN or Inf
             #   Because FitError's are by default caught, this allows fitting to continue
             if not self._check_data:
-                if not np.any(np.isinf(power_spectrum)) or np.any(np.isnan(power_spectrum)):
+                if np.any(np.isinf(self.power_spectrum)) or np.any(np.isnan(self.power_spectrum)):
                     raise FitError("There are NaN or Inf values in the data,  "
                                     "which preclude model fitting.")
 
@@ -703,7 +703,7 @@ class FOOOF():
         self._debug = debug
 
 
-    def set_check_data(self, check_data):
+    def set_check_data_mode(self, check_data):
         """Set check data mode, which controls if an error is raised if NaN or Inf data are added.
 
         Parameters

--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -446,8 +446,8 @@ class FOOOF():
             #   Because FitError's are by default caught, this allows fitting to continue
             if not self._check_data:
                 if np.any(np.isinf(self.power_spectrum)) or np.any(np.isnan(self.power_spectrum)):
-                    raise FitError("There are NaN or Inf values in the data,  "
-                                    "which preclude model fitting.")
+                    raise FitError("Model fitting was skipped because there are NaN or Inf "
+                                   "values in the data, which preclude model fitting.")
 
             # Fit the aperiodic component
             self.aperiodic_params_ = self._robust_ap_fit(self.freqs, self.power_spectrum)
@@ -816,7 +816,8 @@ class FOOOF():
             raise FitError("Model fitting failed due to not finding "
                            "parameters in the robust aperiodic fit.")
         except TypeError:
-            raise FitError("Model fitting failed due to sub-sampling in the robust aperiodic fit.")
+            raise FitError("Model fitting failed due to sub-sampling "
+                           "in the robust aperiodic fit.")
 
         return aperiodic_params
 

--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -39,9 +39,15 @@ _maxfev : int
     The maximum number of calls to the curve fitting function.
 _error_metric : str
     The error metric to use for post-hoc measures of model fit error.
+
+Run Modes
+---------
 _debug : bool
     Whether the object is set in debug mode.
     This should be controlled by using the `set_debug_mode` method.
+_check_data : bool
+    Whether to check added data for NaN or Inf values, and fail out if present.
+    This should be controlled by using the `set_check_data_mode` method.
 
 Code Notes
 ----------
@@ -184,12 +190,16 @@ class FOOOF():
         # The maximum number of calls to the curve fitting function
         self._maxfev = 5000
         # The error metric to calculate, post model fitting. See `_calc_error` for options
-        #   Note: this is used to check error post-hoc, not an objective function for fitting models
+        #   Note: this is for checking error post fitting, not an objective function for fitting
         self._error_metric = 'MAE'
-        # Set whether in debug mode, in which an error is raised if a model fit fails
-        self._debug = False
 
-        # Set internal settings, based on inputs, & initialize data & results attributes
+        ## RUN MODES
+        # Set default debug mode - controls if an error is raised if model fitting is unsuccessful
+        self._debug = False
+        # Set default check data mode - controls if an error is raised if NaN / Inf data are added
+        self._check_data = True
+
+        # Set internal settings, based on inputs, and initialize data & results attributes
         self._reset_internal_settings()
         self._reset_data_results(True, True, True)
 
@@ -311,7 +321,7 @@ class FOOOF():
             self._reset_data_results(True, True, True)
 
         self.freqs, self.power_spectrum, self.freq_range, self.freq_res = \
-            self._prepare_data(freqs, power_spectrum, freq_range, 1, self.verbose)
+            self._prepare_data(freqs, power_spectrum, freq_range, 1)
 
 
     def add_settings(self, fooof_settings):
@@ -430,6 +440,14 @@ class FOOOF():
 
         # In rare cases, the model fails to fit, and so uses try / except
         try:
+
+            # If not set to fail on NaN or Inf data at add time, check data here
+            #   This serves as a catch all for curve_fits which will fail given NaN or Inf
+            #   Because FitError's are by default caught, this allows fitting to continue
+            if not self._check_data:
+                if not np.any(np.isinf(power_spectrum)) or np.any(np.isnan(power_spectrum)):
+                    raise FitError("There are NaN or Inf values in the data,  "
+                                    "which preclude model fitting.")
 
             # Fit the aperiodic component
             self.aperiodic_params_ = self._robust_ap_fit(self.freqs, self.power_spectrum)
@@ -674,7 +692,7 @@ class FOOOF():
 
 
     def set_debug_mode(self, debug):
-        """Set whether debug mode, wherein an error is raised if fitting is unsuccessful.
+        """Set debug mode, which controls if an error is raised if model fitting is unsuccessful.
 
         Parameters
         ----------
@@ -683,6 +701,18 @@ class FOOOF():
         """
 
         self._debug = debug
+
+
+    def set_check_data(self, check_data):
+        """Set check data mode, which controls if an error is raised if NaN or Inf data are added.
+
+        Parameters
+        ----------
+        check_data : bool
+            Whether to run in check data mode.
+        """
+
+        self._check_data = check_data
 
 
     def _check_width_limits(self):
@@ -1101,8 +1131,7 @@ class FOOOF():
             raise ValueError(msg)
 
 
-    @staticmethod
-    def _prepare_data(freqs, power_spectrum, freq_range, spectra_dim=1, verbose=True):
+    def _prepare_data(self, freqs, power_spectrum, freq_range, spectra_dim=1):
         """Prepare input data for adding to current object.
 
         Parameters
@@ -1116,8 +1145,6 @@ class FOOOF():
             Frequency range to restrict power spectrum to. If None, keeps the entire range.
         spectra_dim : int, optional, default: 1
             Dimensionality that the power spectra should have.
-        verbose : bool, optional
-            Whether to be verbose in printing out warnings.
 
         Returns
         -------
@@ -1172,7 +1199,7 @@ class FOOOF():
         #   Aperiodic fit gets an inf if freq of 0 is included, which leads to an error
         if freqs[0] == 0.0:
             freqs, power_spectrum = trim_spectrum(freqs, power_spectrum, [freqs[1], freqs.max()])
-            if verbose:
+            if self.verbose:
                 print("\nFOOOF WARNING: Skipping frequency == 0, "
                       "as this causes a problem with fitting.")
 
@@ -1183,12 +1210,13 @@ class FOOOF():
         # Log power values
         power_spectrum = np.log10(power_spectrum)
 
-        # Check if there are any infs / nans, and raise an error if so
-        if np.any(np.isinf(power_spectrum)) or np.any(np.isnan(power_spectrum)):
-            raise DataError("The input power spectra data, after logging, contains NaNs or Infs. "
-                            "This will cause the fitting to fail. "
-                            "One reason this can happen is if inputs are already logged. "
-                            "Inputs data should be in linear spacing, not log.")
+        if self._check_data:
+            # Check if there are any infs / nans, and raise an error if so
+            if np.any(np.isinf(power_spectrum)) or np.any(np.isnan(power_spectrum)):
+                raise DataError("The input power spectra data, after logging, contains NaNs or Infs. "
+                                "This will cause the fitting to fail. "
+                                "One reason this can happen is if inputs are already logged. "
+                                "Inputs data should be in linear spacing, not log.")
 
         return freqs, power_spectrum, freq_range, freq_res
 

--- a/fooof/objs/group.py
+++ b/fooof/objs/group.py
@@ -476,8 +476,9 @@ class FOOOFGroup(FOOOF):
             The FOOOFResults data loaded into a FOOOF object.
         """
 
-        # Initialize a FOOOF object, with same settings as current FOOOFGroup
+        # Initialize a FOOOF object, with same settings & check data mode as current FOOOFGroup
         fm = FOOOF(*self.get_settings(), verbose=self.verbose)
+        fm.set_check_data_mode(self._check_data)
 
         # Add data for specified single power spectrum, if available
         #   The power spectrum is inverted back to linear, as it is re-logged when added to FOOOF

--- a/fooof/objs/group.py
+++ b/fooof/objs/group.py
@@ -222,7 +222,7 @@ class FOOOFGroup(FOOOF):
             self._reset_group_results()
 
         self.freqs, self.power_spectra, self.freq_range, self.freq_res = \
-            self._prepare_data(freqs, power_spectra, freq_range, 2, self.verbose)
+            self._prepare_data(freqs, power_spectra, freq_range, 2)
 
 
     def report(self, freqs=None, power_spectra=None, freq_range=None, n_jobs=1, progress=None):

--- a/fooof/objs/utils.py
+++ b/fooof/objs/utils.py
@@ -178,6 +178,9 @@ def combine_fooofs(fooofs):
     if len(fg) == temp_power_spectra.shape[0]:
         fg.power_spectra = temp_power_spectra
 
+    # Set the check data mode, as True if any of the inputs have it on, False otherwise
+    fg.set_check_data_mode(any([getattr(f_obj, '_check_data') for f_obj in fooofs]))
+
     # Add data information information
     fg.add_meta_data(fooofs[0].get_meta_data())
 

--- a/fooof/tests/objs/test_fit.py
+++ b/fooof/tests/objs/test_fit.py
@@ -392,4 +392,4 @@ def test_fooof_check_data():
 
     # Model fitting should execute, but return a null model fit, given the NaNs, without failing
     tfm.fit()
-    assert not fm.has_model
+    assert not tfm.has_model


### PR DESCRIPTION
Responds to #175 

This PR adds the `check_data` mode to FOOOF objects, which controls if added data is checked for NaN/Inf data-points, and fails out if so. By default, `check_data` is turned on, in which case objects act the same as before. 

However, this mode can be turned off, in which case the object plays nice with having NaN/Inf data. Model fitting will cleanly fail (no error) and so fitting can continue. This allows for fitting groups of spectra in which some spectra are NaN, and makes it easier to deal with messy shaped data in which some spectra may be missing, etc. 

So far the decision here is to not change default behaviour, but add an option for users to bypass some of the data checks. This, I think, is a safer option - the user has to choose when to ignore NaN data, and should only do so if they know why it is happening, etc. 

Note: this is an issue brought up by @mwprestonjr. MJ - whenever you get a chance, can you have a look at this proposal, and see if it addresses your use case, and check in whether you think this is a good solution for your purposes? Thanks!

### Examples

By default, this code will error, as before:
```
from fooof import FOOOF
from fooof.sim import gen_power_spectrum

freqs, pows = gen_power_spectrum([3, 50], [1, 1], [10, 0.2, 1])
pows[:] = np.nan

fm = FOOOF()
fm.fit(freqs, pows)
```

But, with explicit toggle of the check data mode, this will no longer throw an explicit error:
```
fm = FOOOF()
fm.set_check_data_mode(False)
fm.fit(freqs, pows)
```

This is probably most relevant for cases, with FOOOFGroup, whereby some spectra may be null:
```
from fooof import FOOOF, FOOOFGroup
from fooof.sim import gen_group_power_spectra

freqs, pows = gen_group_power_spectra(3, [3, 50], [1, 1], [10, 0.2, 1])
pows[1, :] = np.nan

fg = FOOOFGroup()
fg.set_check_data_mode(False)
fg.fit(freqs, pows)
```

Note, in the above, that by default (or if `set_check_data_mode(True)` is called, which returns the object to default mode of having check_data on), the above code fails. 