### PR TITLE
[MNT] - Update peak extraction array & describe index column

### DIFF
--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -586,9 +586,7 @@ class FOOOF():
 
         Notes
         -----
-        For further description of the data you can extract, check the FOOOFResults documentation.
-
-        If there is no data on periodic features, this method will return NaN.
+        If there are no fit peak (no peak parameters), this method will return NaN.
         """
 
         if not self.has_model:

--- a/fooof/objs/group.py
+++ b/fooof/objs/group.py
@@ -375,20 +375,17 @@ class FOOOFGroup(FOOOF):
         # As a special case, peak_params are pulled out in a way that appends
         #  an extra column, indicating which FOOOF run each peak comes from
         if name in ('peak_params', 'gaussian_params'):
-            out = np.array([np.insert(getattr(data, name), 3, index, axis=1)
-                            for index, data in enumerate(self.group_results)])
+
+            # Collect peak data, appending the index of the model it comes from
+            out = np.vstack([np.insert(getattr(data, name), 3, index, axis=1)
+                             for index, data in enumerate(self.group_results)])
+
             # This updates index to grab selected column, and the last column
             #  This last column is the 'index' column (FOOOF object source)
             if col is not None:
                 col = [col, -1]
         else:
             out = np.array([getattr(data, name) for data in self.group_results])
-
-        # Some data can end up as a list of separate arrays
-        #   If so, concatenate it all into one 2d array
-        if isinstance(out[0], np.ndarray):
-            out = np.concatenate([arr.reshape(1, len(arr)) \
-                if arr.ndim == 1 else arr for arr in out], 0)
 
         # Select out a specific column, if requested
         if col is not None:

--- a/fooof/objs/group.py
+++ b/fooof/objs/group.py
@@ -354,7 +354,8 @@ class FOOOFGroup(FOOOF):
 
         Notes
         -----
-        For further description of the data you can extract, check the FOOOFResults documentation.
+        When extracting peak informartion ('peak_params' or 'gaussian_params'), an additional column
+        is appended to the returned array, indicating the index of the model that the peak came from.
         """
 
         if not self.has_model:

--- a/fooof/objs/group.py
+++ b/fooof/objs/group.py
@@ -354,7 +354,7 @@ class FOOOFGroup(FOOOF):
 
         Notes
         -----
-        When extracting peak informartion ('peak_params' or 'gaussian_params'), an additional column
+        When extracting peak information ('peak_params' or 'gaussian_params'), an additional column
         is appended to the returned array, indicating the index of the model that the peak came from.
         """
 


### PR DESCRIPTION
As mentioned in this issue (#192) - there is a deprecation with newer numpy on how we were managing peak parameters in FOOOFGroup.get_params. Issue was we were calling `np.array` on a list of array. This can simply be replaced by `np.vstack`, to avoid the issue with typecasting the messy list object to an array. 