### PR TITLE
[ENH] Combined plot_spectra and plot_spectrum

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -247,7 +247,6 @@ Plots for visualizing power spectra.
 .. autosummary::
     :toctree: generated/
 
-    plot_spectrum
     plot_spectra
 
 Plots for plotting power spectra with shaded regions.
@@ -257,7 +256,6 @@ Plots for plotting power spectra with shaded regions.
 .. autosummary::
     :toctree: generated/
 
-    plot_spectrum_shading
     plot_spectra_shading
 
 Plot Model Properties & Parameters

--- a/examples/analyses/plot_mne_example.py
+++ b/examples/analyses/plot_mne_example.py
@@ -32,7 +32,7 @@ from mne.time_frequency import psd_welch
 from fooof import FOOOFGroup
 from fooof.bands import Bands
 from fooof.analysis import get_band_peak_fg
-from fooof.plts.spectra import plot_spectrum
+from fooof.plts.spectra import plot_spectra
 
 ###################################################################################################
 # Load & Check MNE Data
@@ -284,10 +284,10 @@ plot_topomap(exps, raw.info, cmap=cm.viridis, contours=0)
 
 # Compare the power spectra between low and high exponent channels
 fig, ax = plt.subplots(figsize=(8, 6))
-plot_spectrum(fg.freqs, fg.get_fooof(np.argmin(exps)).power_spectrum,
-              ax=ax, label='Low Exponent')
-plot_spectrum(fg.freqs, fg.get_fooof(np.argmax(exps)).power_spectrum,
-              ax=ax, label='High Exponent')
+plot_spectra(fg.freqs, fg.get_fooof(np.argmin(exps)).power_spectrum,
+             ax=ax, label='Low Exponent')
+plot_spectra(fg.freqs, fg.get_fooof(np.argmax(exps)).power_spectrum,
+             ax=ax, label='High Exponent')
 
 ###################################################################################################
 # Conclusion

--- a/examples/analyses/plot_mne_example.py
+++ b/examples/analyses/plot_mne_example.py
@@ -284,10 +284,11 @@ plot_topomap(exps, raw.info, cmap=cm.viridis, contours=0)
 
 # Compare the power spectra between low and high exponent channels
 fig, ax = plt.subplots(figsize=(8, 6))
-plot_spectra(fg.freqs, fg.get_fooof(np.argmin(exps)).power_spectrum,
-             ax=ax, label='Low Exponent')
-plot_spectra(fg.freqs, fg.get_fooof(np.argmax(exps)).power_spectrum,
-             ax=ax, label='High Exponent')
+
+spectra = [fg.get_fooof(np.argmin(exps)).power_spectrum,
+           fg.get_fooof(np.argmax(exps)).power_spectrum]
+
+plot_spectra(fg.freqs, spectra, ax=ax, labels=['Low Exponent', 'High Exponent'])
 
 ###################################################################################################
 # Conclusion

--- a/examples/plots/plot_power_spectra.py
+++ b/examples/plots/plot_power_spectra.py
@@ -157,5 +157,5 @@ fig, ax = plt.subplots(figsize=[12, 8])
 plot_spectra_shading(freqs_al, powers_al, [8, 12],
                      log_powers=True, alpha=0.6, ax=ax)
 plot_spectra(freqs_al10, powers_al10, log_powers=True,
-              color='black', linewidth=3, label='10 Hz Alpha', ax=ax)
+             color='black', linewidth=3, label='10 Hz Alpha', ax=ax)
 plt.title('Comparing Alphas', {'fontsize' : 20, 'fontweight' : 'bold'});

--- a/examples/plots/plot_power_spectra.py
+++ b/examples/plots/plot_power_spectra.py
@@ -11,8 +11,7 @@ Visualizing power spectra.
 import matplotlib.pyplot as plt
 
 # Import plotting functions
-from fooof.plts.spectra import plot_spectrum, plot_spectra
-from fooof.plts.spectra import plot_spectrum_shading, plot_spectra_shading
+from fooof.plts.spectra import plot_spectra, plot_spectra_shading
 
 # Import simulation utilities for creating test data
 from fooof.sim.gen import gen_power_spectrum, gen_group_power_spectra
@@ -59,7 +58,7 @@ freqs, powers2 = gen_power_spectrum(freq_range, ap_2, peaks)
 #
 # First we will start with the core plotting function that plots an individual power spectrum.
 #
-# The :func:`~.plot_spectrum` function takes in an array of frequency values and a 1d array of
+# The :func:`~.plot_spectra` function takes in an array of frequency values and a 1d array of
 # of power values, and plots the corresponding power spectrum.
 #
 # This function, as all the functions in the plotting module, takes in optional inputs
@@ -70,7 +69,7 @@ freqs, powers2 = gen_power_spectrum(freq_range, ap_2, peaks)
 ###################################################################################################
 
 # Create a spectrum plot with a single power spectrum
-plot_spectrum(freqs, powers1, log_powers=True)
+plot_spectra(freqs, powers1, log_powers=True)
 
 ###################################################################################################
 # Plotting Multiple Power Spectra
@@ -97,7 +96,7 @@ plot_spectra(freqs, [powers1, powers2], log_freqs=True, log_powers=True, labels=
 # In some cases it may be useful to highlight or shade in particular frequency regions,
 # for example, when examining power in particular frequency regions.
 #
-# The :func:`~.plot_spectrum_shading` function takes in a power spectrum and one or more
+# The :func:`~.plot_spectra_shading` function takes in a power spectrum and one or more
 # shaded regions, and plot the power spectrum with the indicated region shaded.
 #
 # The same can be done for multiple power spectra with :func:`~.plot_spectra_shading`.
@@ -110,7 +109,7 @@ plot_spectra(freqs, [powers1, powers2], log_freqs=True, log_powers=True, labels=
 ###################################################################################################
 
 # Plot a single power spectrum, with a shaded region covering alpha
-plot_spectrum_shading(freqs, powers1, [8, 12], log_powers=True)
+plot_spectra_shading(freqs, powers1, [8, 12], log_powers=True)
 
 ###################################################################################################
 
@@ -157,6 +156,6 @@ freqs_al, powers_al = gen_group_power_spectra(len(cf_steps), freq_range, ap_para
 fig, ax = plt.subplots(figsize=[12, 8])
 plot_spectra_shading(freqs_al, powers_al, [8, 12],
                      log_powers=True, alpha=0.6, ax=ax)
-plot_spectrum(freqs_al10, powers_al10, log_powers=True,
+plot_spectra(freqs_al10, powers_al10, log_powers=True,
               color='black', linewidth=3, label='10 Hz Alpha', ax=ax)
 plt.title('Comparing Alphas', {'fontsize' : 20, 'fontweight' : 'bold'});

--- a/examples/sims/plot_simulated_power_spectra.py
+++ b/examples/sims/plot_simulated_power_spectra.py
@@ -11,7 +11,7 @@ Creating simulated power spectra.
 from fooof.sim.gen import gen_power_spectrum, gen_group_power_spectra
 
 # Import plotting functions
-from fooof.plts.spectra import plot_spectrum, plot_spectra
+from fooof.plts.spectra import plot_spectra
 
 ###################################################################################################
 # Creating Simulated Power Spectra
@@ -53,7 +53,7 @@ freqs, powers = gen_power_spectrum(freq_range, aperiodic_params, periodic_params
 ###################################################################################################
 
 # Plot the simulated power spectrum
-plot_spectrum(freqs, powers, log_freqs=True, log_powers=False)
+plot_spectra(freqs, powers, log_freqs=True, log_powers=False)
 
 ###################################################################################################
 # Simulating With Different Parameters
@@ -100,7 +100,7 @@ freqs, powers = gen_power_spectrum(freq_range, aperiodic_params,
 ###################################################################################################
 
 # Plot the new simulated power spectrum
-plot_spectrum(freqs, powers, log_powers=True)
+plot_spectra(freqs, powers, log_powers=True)
 
 ###################################################################################################
 # Simulating a Group of Power Spectra

--- a/fooof/plts/__init__.py
+++ b/fooof/plts/__init__.py
@@ -1,3 +1,4 @@
 """Plots sub-module for FOOOF."""
 
-from .spectra import plot_spectrum, plot_spectra
+from .spectra import plot_spectra
+from .spectra import plot_spectra as plot_spectrum

--- a/fooof/plts/annotate.py
+++ b/fooof/plts/annotate.py
@@ -8,7 +8,7 @@ from fooof.core.funcs import gaussian_function
 from fooof.core.modutils import safe_import, check_dependency
 from fooof.sim.gen import gen_aperiodic
 from fooof.plts.utils import check_ax
-from fooof.plts.spectra import plot_spectrum
+from fooof.plts.spectra import plot_spectra
 from fooof.plts.settings import PLT_FIGSIZES, PLT_COLORS
 from fooof.plts.style import check_n_style, style_spectrum_plot
 from fooof.analysis.periodic import get_band_peak_fm
@@ -46,14 +46,14 @@ def plot_annotated_peak_search(fm, plot_style=style_spectrum_plot):
         # This forces the creation of a new plotting axes per iteration
         ax = check_ax(None, PLT_FIGSIZES['spectral'])
 
-        plot_spectrum(fm.freqs, flatspec, ax=ax, plot_style=None,
-                      label='Flattened Spectrum', color=PLT_COLORS['data'], linewidth=2.5)
-        plot_spectrum(fm.freqs, [fm.peak_threshold * np.std(flatspec)]*len(fm.freqs),
-                      ax=ax, plot_style=None, label='Relative Threshold',
-                      color='orange', linewidth=2.5, linestyle='dashed')
-        plot_spectrum(fm.freqs, [fm.min_peak_height]*len(fm.freqs),
-                      ax=ax, plot_style=None, label='Absolute Threshold',
-                      color='red', linewidth=2.5, linestyle='dashed')
+        plot_spectra(fm.freqs, flatspec, ax=ax, plot_style=None,
+                     label='Flattened Spectrum', color=PLT_COLORS['data'], linewidth=2.5)
+        plot_spectra(fm.freqs, [fm.peak_threshold * np.std(flatspec)]*len(fm.freqs),
+                     ax=ax, plot_style=None, label='Relative Threshold',
+                     color='orange', linewidth=2.5, linestyle='dashed')
+        plot_spectra(fm.freqs, [fm.min_peak_height]*len(fm.freqs),
+                     ax=ax, plot_style=None, label='Absolute Threshold',
+                     color='red', linewidth=2.5, linestyle='dashed')
 
         maxi = np.argmax(flatspec)
         ax.plot(fm.freqs[maxi], flatspec[maxi], '.',
@@ -65,9 +65,9 @@ def plot_annotated_peak_search(fm, plot_style=style_spectrum_plot):
         if ind < fm.n_peaks_:
 
             gauss = gaussian_function(fm.freqs, *fm.gaussian_params_[ind, :])
-            plot_spectrum(fm.freqs, gauss, ax=ax, plot_style=None,
-                          label='Gaussian Fit', color=PLT_COLORS['periodic'],
-                          linestyle=':', linewidth=3.0)
+            plot_spectra(fm.freqs, gauss, ax=ax, plot_style=None,
+                         label='Gaussian Fit', color=PLT_COLORS['periodic'],
+                         linestyle=':', linewidth=3.0)
 
             flatspec = flatspec - gauss
 

--- a/fooof/plts/error.py
+++ b/fooof/plts/error.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from fooof.core.modutils import safe_import, check_dependency
-from fooof.plts.spectra import plot_spectrum
+from fooof.plts.spectra import plot_spectra
 from fooof.plts.settings import PLT_FIGSIZES
 from fooof.plts.style import check_n_style, style_spectrum_plot
 from fooof.plts.utils import check_ax
@@ -41,7 +41,7 @@ def plot_spectral_error(freqs, error, shade=None, log_freqs=False,
 
     plt_freqs = np.log10(freqs) if log_freqs else freqs
 
-    plot_spectrum(plt_freqs, error, plot_style=None, ax=ax, linewidth=3, **plot_kwargs)
+    plot_spectra(plt_freqs, error, plot_style=None, ax=ax, linewidth=3, **plot_kwargs)
 
     if np.any(shade):
         ax.fill_between(plt_freqs, error-shade, error+shade, alpha=0.25)

--- a/fooof/plts/error.py
+++ b/fooof/plts/error.py
@@ -40,7 +40,7 @@ def plot_spectral_error(freqs, error, shade=None, log_freqs=False, ax=None, **pl
 
     plt_freqs = np.log10(freqs) if log_freqs else freqs
 
-    plot_spectrum(plt_freqs, error, ax=ax, linewidth=3)
+    plot_spectra(plt_freqs, error, ax=ax, linewidth=3)
 
     if np.any(shade):
         ax.fill_between(plt_freqs, error-shade, error+shade, alpha=0.25)

--- a/fooof/plts/fm.py
+++ b/fooof/plts/fm.py
@@ -13,7 +13,7 @@ from fooof.core.modutils import safe_import, check_dependency
 from fooof.sim.gen import gen_periodic
 from fooof.utils.data import trim_spectrum
 from fooof.utils.params import compute_fwhm
-from fooof.plts.spectra import plot_spectrum
+from fooof.plts.spectra import plot_spectra
 from fooof.plts.settings import PLT_FIGSIZES, PLT_COLORS
 from fooof.plts.utils import check_ax, check_plot_kwargs
 from fooof.plts.style import check_n_style, style_spectrum_plot
@@ -73,24 +73,24 @@ def plot_fm(fm, plot_peaks=None, plot_aperiodic=True, plt_log=False, add_legend=
         data_kwargs = check_plot_kwargs(data_kwargs, \
             {'color' : PLT_COLORS['data'], 'linewidth' : 2.0,
              'label' : 'Original Spectrum' if add_legend else None})
-        plot_spectrum(fm.freqs, fm.power_spectrum, log_freqs, log_powers,
-                      ax=ax, plot_style=None, **data_kwargs)
+        plot_spectra(fm.freqs, fm.power_spectrum, log_freqs, log_powers,
+                     ax=ax, plot_style=None, **data_kwargs)
 
     # Add the full model fit, and components (if requested)
     if fm.has_model:
         model_kwargs = check_plot_kwargs(model_kwargs, \
             {'color' : PLT_COLORS['model'], 'linewidth' : 3.0, 'alpha' : 0.5,
              'label' : 'Full Model Fit' if add_legend else None})
-        plot_spectrum(fm.freqs, fm.fooofed_spectrum_, log_freqs, log_powers,
-                      ax=ax, plot_style=None, **model_kwargs)
+        plot_spectra(fm.freqs, fm.fooofed_spectrum_, log_freqs, log_powers,
+                     ax=ax, plot_style=None, **model_kwargs)
 
         # Plot the aperiodic component of the model fit
         if plot_aperiodic:
             aperiodic_kwargs = check_plot_kwargs(aperiodic_kwargs, \
                 {'color' : PLT_COLORS['aperiodic'], 'linewidth' : 3.0, 'alpha' : 0.5,
                  'linestyle' : 'dashed', 'label' : 'Aperiodic Fit' if add_legend else None})
-            plot_spectrum(fm.freqs, fm._ap_fit, log_freqs, log_powers,
-                          ax=ax, plot_style=None, **aperiodic_kwargs)
+            plot_spectra(fm.freqs, fm._ap_fit, log_freqs, log_powers,
+                         ax=ax, plot_style=None, **aperiodic_kwargs)
 
         # Plot the periodic components of the model fit
         if plot_peaks:

--- a/fooof/plts/spectra.py
+++ b/fooof/plts/spectra.py
@@ -12,7 +12,7 @@ import numpy as np
 from fooof.core.modutils import safe_import, check_dependency
 from fooof.plts.settings import PLT_FIGSIZES
 from fooof.plts.style import style_spectrum_plot, style_plot
-from fooof.plts.utils import check_ax, add_shades, savefig
+from fooof.plts.utils import check_ax, add_shades, savefig, check_plot_kwargs
 
 plt = safe_import('.pyplot', 'matplotlib')
 
@@ -36,10 +36,10 @@ def plot_spectra(freqs, power_spectra, log_freqs=False, log_powers=False,
         Whether to plot the frequency axis in log spacing.
     log_powers : bool, optional, default: False
         Whether to plot the power axis in log spacing.
-    labels : list of str, optional, default: None
-        Legend labels for the spectra.
     colors : list of str, optional, default: None
         Line colors of the spectra.
+    labels : list of str, optional, default: None
+        Legend labels for the spectra.
     ax : matplotlib.Axes, optional
         Figure axes upon which to plot.
     **plot_kwargs
@@ -64,15 +64,17 @@ def plot_spectra(freqs, power_spectra, log_freqs=False, log_powers=False,
     # Plot
     for freqs, powers, color, label in zip(plt_freqs, plt_powers, colors, labels):
 
-        # Set plot data, logging if requested
+        # Set plot data, logging if requested, and collect color, if absent
         freqs = np.log10(freqs) if log_freqs else freqs
         powers = np.log10(powers) if log_powers else powers
+        if color:
+            plot_kwargs['color'] = color
 
-        ax.plot(freqs, powers, color=color, label=label, **plot_kwargs)
+        ax.plot(freqs, powers, label=label, **plot_kwargs)
 
     style_spectrum_plot(ax, log_freqs, log_powers)
 
-    
+
 @savefig
 @check_dependency(plt, 'matplotlib')
 def plot_spectra_shading(freqs, power_spectra, shades, shade_colors='r',

--- a/fooof/plts/spectra.py
+++ b/fooof/plts/spectra.py
@@ -19,41 +19,6 @@ plt = safe_import('.pyplot', 'matplotlib')
 ###################################################################################################
 ###################################################################################################
 
-@check_dependency(plt, 'matplotlib')
-def plot_spectrum(freqs, power_spectrum, log_freqs=False, log_powers=False,
-                  ax=None, plot_style=style_spectrum_plot, **plot_kwargs):
-    """Plot a power spectrum.
-
-    Parameters
-    ----------
-    freqs : 1d array
-        Frequency values, to be plotted on the x-axis.
-    power_spectrum : 1d array
-        Power values, to be plotted on the y-axis.
-    log_freqs : bool, optional, default: False
-        Whether to plot the frequency axis in log spacing.
-    log_powers : bool, optional, default: False
-        Whether to plot the power axis in log spacing.
-    ax : matplotlib.Axes, optional
-        Figure axis upon which to plot.
-    plot_style : callable, optional, default: style_spectrum_plot
-        A function to call to apply styling & aesthetics to the plot.
-    **plot_kwargs
-        Keyword arguments to be passed to the plot call.
-    """
-
-    ax = check_ax(ax, plot_kwargs.pop('figsize', PLT_FIGSIZES['spectral']))
-
-    # Set plot data & labels, logging if requested
-    plt_freqs = np.log10(freqs) if log_freqs else freqs
-    plt_powers = np.log10(power_spectrum) if log_powers else power_spectrum
-
-    # Create the plot
-    plot_kwargs = check_plot_kwargs(plot_kwargs, {'linewidth' : 2.0})
-    ax.plot(plt_freqs, plt_powers, **plot_kwargs)
-
-    check_n_style(plot_style, ax, log_freqs, log_powers)
-
 
 @check_dependency(plt, 'matplotlib')
 def plot_spectra(freqs, power_spectra, log_freqs=False, log_powers=False, labels=None,
@@ -82,51 +47,28 @@ def plot_spectra(freqs, power_spectra, log_freqs=False, log_powers=False, labels
 
     ax = check_ax(ax, plot_kwargs.pop('figsize', PLT_FIGSIZES['spectral']))
 
+    # Create the plot
+    plot_kwargs = check_plot_kwargs(plot_kwargs, {'linewidth' : 2.0})
+
     # Make inputs iterable if need to be passed multiple times to plot each spectrum
-    freqs = repeat(freqs) if isinstance(freqs, np.ndarray) and freqs.ndim == 1 else freqs
+    plt_powers = np.reshape(power_spectra, (1, -1)) if np.ndim(power_spectra) == 1 else \
+        power_spectra
+    plt_freqs = repeat(freqs) if isinstance(freqs, np.ndarray) and freqs.ndim == 1 else freqs
+
+    # Set labels
+    labels = plot_kwargs.pop('label') if 'label' in plot_kwargs.keys() and labels is None else labels
     labels = repeat(labels) if not isinstance(labels, list) else labels
 
-    for freq, power_spectrum, label in zip(freqs, power_spectra, labels):
-        plot_spectrum(freq, power_spectrum, log_freqs, log_powers, label=label,
-                      plot_style=None, ax=ax, **plot_kwargs)
+    # Plot
+    for freqs, powers, label in zip(plt_freqs, plt_powers, labels):
+
+        # Set plot data & labels, logging if requested
+        freqs = np.log10(freqs) if log_freqs else freqs
+        powers = np.log10(powers) if log_powers else powers
+
+        ax.plot(freqs, powers, label=label, **plot_kwargs)
 
     check_n_style(plot_style, ax, log_freqs, log_powers)
-
-
-@check_dependency(plt, 'matplotlib')
-def plot_spectrum_shading(freqs, power_spectrum, shades, shade_colors='r', add_center=False,
-                          ax=None, plot_style=style_spectrum_plot, **plot_kwargs):
-    """Plot a power spectrum with a shaded frequency region (or regions).
-
-    Parameters
-    ----------
-    freqs : 1d array
-        Frequency values, to be plotted on the x-axis.
-    power_spectrum : 1d array
-        Power values, to be plotted on the y-axis.
-    shades : list of [float, float] or list of list of [float, float]
-        Shaded region(s) to add to plot, defined as [lower_bound, upper_bound].
-    shade_colors : str or list of string
-        Color(s) to plot shades.
-    add_center : bool, optional, default: False
-        Whether to add a line at the center point of the shaded regions.
-    ax : matplotlib.Axes, optional
-        Figure axes upon which to plot.
-    plot_style : callable, optional, default: style_spectrum_plot
-        A function to call to apply styling & aesthetics to the plot.
-    **plot_kwargs
-        Keyword arguments to be passed to the plot call.
-    """
-
-    ax = check_ax(ax, plot_kwargs.pop('figsize', PLT_FIGSIZES['spectral']))
-
-    plot_spectrum(freqs, power_spectrum, plot_style=None, ax=ax, **plot_kwargs)
-
-    add_shades(ax, shades, shade_colors, add_center, plot_kwargs.get('log_freqs', False))
-
-    check_n_style(plot_style, ax,
-                  plot_kwargs.get('log_freqs', False),
-                  plot_kwargs.get('log_powers', False))
 
 
 @check_dependency(plt, 'matplotlib')

--- a/fooof/plts/spectra.py
+++ b/fooof/plts/spectra.py
@@ -24,13 +24,13 @@ plt = safe_import('.pyplot', 'matplotlib')
 @check_dependency(plt, 'matplotlib')
 def plot_spectra(freqs, power_spectra, log_freqs=False, log_powers=False,
                  colors=None, labels=None, ax=None, **plot_kwargs):
-    """Plot multiple power spectra on the same plot.
+    """Plot one or multiple power spectra.
 
     Parameters
     ----------
-    freqs : 2d array or 1d array or list of 1d array
+    freqs : 1d or 2d array or list of 1d array
         Frequency values, to be plotted on the x-axis.
-    power_spectra : 2d array or list of 1d array
+    power_spectra : 1d or 2d array or list of 1d array
         Power values, to be plotted on the y-axis.
     log_freqs : bool, optional, default: False
         Whether to plot the frequency axis in log spacing.
@@ -79,13 +79,13 @@ def plot_spectra(freqs, power_spectra, log_freqs=False, log_powers=False,
 @check_dependency(plt, 'matplotlib')
 def plot_spectra_shading(freqs, power_spectra, shades, shade_colors='r',
                          add_center=False, ax=None, **plot_kwargs):
-    """Plot a group of power spectra with a shaded frequency region (or regions).
+    """Plot one or multiple power spectra with a shaded frequency region (or regions).
 
     Parameters
     ----------
-    freqs : 2d array or 1d array or list of 1d array
+    freqs : 1d or 2d array or list of 1d array
         Frequency values, to be plotted on the x-axis.
-    power_spectra : 2d array or list of 1d array
+    power_spectra : 1d or 2d array or list of 1d array
         Power values, to be plotted on the y-axis.
     shades : list of [float, float] or list of list of [float, float]
         Shaded region(s) to add to plot, defined as [lower_bound, upper_bound].

--- a/fooof/tests/plts/test_spectra.py
+++ b/fooof/tests/plts/test_spectra.py
@@ -10,15 +10,10 @@ from fooof.plts.spectra import *
 ###################################################################################################
 
 @plot_test
-def test_plot_spectrum(tfm, skip_if_no_mpl):
+def test_plot_spectra(tfm, tfg, skip_if_no_mpl):
 
-    plot_spectrum(tfm.freqs, tfm.power_spectrum)
-
-    # Test with logging both axes
-    plot_spectrum(tfm.freqs, tfm.power_spectrum, True, True)
-
-@plot_test
-def test_plot_spectra(tfg, skip_if_no_mpl):
+    # Test with 1d inputs - 1d freq array and 1d power spectrum
+    plot_spectra(tfm.freqs, tfm.power_spectrum)
 
     # Test with 1d inputs - 1d freq array and list of 1d power spectra
     plot_spectra(tfg.freqs, [tfg.power_spectra[0, :], tfg.power_spectra[1, :]])
@@ -34,12 +29,9 @@ def test_plot_spectra(tfg, skip_if_no_mpl):
     plot_spectra(tfg.freqs, [tfg.power_spectra[0, :], tfg.power_spectra[1, :]], labels=['A', 'B'])
 
 @plot_test
-def test_plot_spectrum_shading(tfm, skip_if_no_mpl):
+def test_plot_spectra_shading(tfm, tfg, skip_if_no_mpl):
 
-    plot_spectrum_shading(tfm.freqs, tfm.power_spectrum, shades=[8, 12], add_center=True)
-
-@plot_test
-def test_plot_spectra_shading(tfg, skip_if_no_mpl):
+    plot_spectra_shading(tfm.freqs, tfm.power_spectrum, shades=[8, 12], add_center=True)
 
     plot_spectra_shading(tfg.freqs, [tfg.power_spectra[0, :], tfg.power_spectra[1, :]],
                          shades=[8, 12], add_center=True)

--- a/fooof/tests/plts/test_spectra.py
+++ b/fooof/tests/plts/test_spectra.py
@@ -12,9 +12,9 @@ from fooof.plts.spectra import *
 
 @plot_test
 def test_plot_spectra(tfm, tfg, skip_if_no_mpl):
-  
+
     # Test with 1d inputs - 1d freq array and list of 1d power spectra
-    plot_spectra(tfm.freqs, tfm.power_spectrum, 
+    plot_spectra(tfm.freqs, tfm.power_spectrum,
                  save_fig=True, file_path=TEST_PLOTS_PATH, file_name='test_plot_spectra_1d.png')
 
     # Test with 1d inputs - 1d freq array and list of 1d power spectra
@@ -37,10 +37,10 @@ def test_plot_spectra(tfm, tfg, skip_if_no_mpl):
 
 @plot_test
 def test_plot_spectra_shading(tfm, tfg, skip_if_no_mpl):
-  
-    plot_spectrum_shading(tfm.freqs, tfm.power_spectrum, shades=[8, 12], add_center=True,
-                          save_fig=True, file_path=TEST_PLOTS_PATH,
-                          file_name='test_plot_spectrum_shading1.png')
+
+    plot_spectra_shading(tfm.freqs, tfm.power_spectrum, shades=[8, 12], add_center=True,
+                         save_fig=True, file_path=TEST_PLOTS_PATH,
+                         file_name='test_plot_spectrum_shading1.png')
 
     plot_spectra_shading(tfg.freqs, [tfg.power_spectra[0, :], tfg.power_spectra[1, :]],
                          shades=[8, 12], add_center=True, save_fig=True, file_path=TEST_PLOTS_PATH,

--- a/motivations/measurements/plot_BandRatios.py
+++ b/motivations/measurements/plot_BandRatios.py
@@ -44,7 +44,7 @@ from fooof.bands import Bands
 from fooof.utils import trim_spectrum
 from fooof.sim.gen import gen_power_spectrum
 from fooof.sim.utils import set_random_seed
-from fooof.plts.spectra import plot_spectrum_shading, plot_spectra_shading
+from fooof.plts.spectra import plot_spectra_shading
 
 ###################################################################################################
 
@@ -124,9 +124,9 @@ def calc_band_ratio(freqs, powers, low_band, high_band):
 ###################################################################################################
 
 # Plot the power spectrum, shading the frequency bands used for the ratio
-plot_spectrum_shading(freqs, powers, [bands.theta, bands.beta],
-                      color='black', shade_colors=shade_color,
-                      log_powers=True, linewidth=3.5)
+plot_spectra_shading(freqs, powers, [bands.theta, bands.beta],
+                     color='black', shade_colors=shade_color,
+                     log_powers=True, linewidth=3.5)
 
 ###################################################################################################
 

--- a/tutorials/plot_01-ModelDescription.py
+++ b/tutorials/plot_01-ModelDescription.py
@@ -41,7 +41,7 @@ A description of and introduction to the power spectrum model.
 from fooof import FOOOF
 from fooof.sim.gen import gen_power_spectrum
 from fooof.sim.utils import set_random_seed
-from fooof.plts.spectra import plot_spectrum
+from fooof.plts.spectra import plot_spectra
 from fooof.plts.annotate import plot_annotated_model
 
 ###################################################################################################
@@ -81,8 +81,8 @@ fm2.fit(freqs2, powers2)
 ###################################################################################################
 
 # Plot one of the example power spectra
-plot_spectrum(freqs1, powers1, log_powers=True,
-              color='black', label='Original Spectrum')
+plot_spectra(freqs1, powers1, log_powers=True,
+             color='black', label='Original Spectrum')
 
 ###################################################################################################
 # Conceptual Overview

--- a/tutorials/plot_03-FOOOFAlgorithm.py
+++ b/tutorials/plot_03-FOOOFAlgorithm.py
@@ -41,7 +41,7 @@ from fooof import FOOOF
 #   These are used here to demonstrate the algorithm
 #   You do not need to import these functions for standard usage of the module
 from fooof.sim.gen import gen_aperiodic
-from fooof.plts.spectra import plot_spectrum
+from fooof.plts.spectra import plot_spectra
 from fooof.plts.annotate import plot_annotated_peak_search
 
 # Import a utility to download and load example data
@@ -110,10 +110,10 @@ init_ap_fit = gen_aperiodic(fm.freqs, fm._robust_ap_fit(fm.freqs, fm.power_spect
 
 # Plot the initial aperiodic fit
 _, ax = plt.subplots(figsize=(12, 10))
-plot_spectrum(fm.freqs, fm.power_spectrum, plt_log,
-              label='Original Power Spectrum', color='black', ax=ax)
-plot_spectrum(fm.freqs, init_ap_fit, plt_log, label='Initial Aperiodic Fit',
-              color='blue', alpha=0.5, linestyle='dashed', ax=ax)
+plot_spectra(fm.freqs, fm.power_spectrum, plt_log,
+             label='Original Power Spectrum', color='black', ax=ax)
+plot_spectra(fm.freqs, init_ap_fit, plt_log, label='Initial Aperiodic Fit',
+             color='blue', alpha=0.5, linestyle='dashed', ax=ax)
 
 ###################################################################################################
 # Step 2: Flatten the Spectrum
@@ -131,8 +131,8 @@ plot_spectrum(fm.freqs, init_ap_fit, plt_log, label='Initial Aperiodic Fit',
 init_flat_spec = fm.power_spectrum - init_ap_fit
 
 # Plot the flattened the power spectrum
-plot_spectrum(fm.freqs, init_flat_spec, plt_log,
-              label='Flattened Spectrum', color='black')
+plot_spectra(fm.freqs, init_flat_spec, plt_log,
+             label='Flattened Spectrum', color='black')
 
 ###################################################################################################
 # Step 3: Detect Peaks
@@ -172,7 +172,7 @@ plot_annotated_peak_search(fm)
 ###################################################################################################
 
 # Plot the peak fit: created by re-fitting all of the candidate peaks together
-plot_spectrum(fm.freqs, fm._peak_fit, plt_log, color='green', label='Final Periodic Fit')
+plot_spectra(fm.freqs, fm._peak_fit, plt_log, color='green', label='Final Periodic Fit')
 
 ###################################################################################################
 # Step 5: Create a Peak-Removed Spectrum
@@ -188,8 +188,8 @@ plot_spectrum(fm.freqs, fm._peak_fit, plt_log, color='green', label='Final Perio
 ###################################################################################################
 
 # Plot the peak removed power spectrum, created by removing peak fit from original spectrum
-plot_spectrum(fm.freqs, fm._spectrum_peak_rm, plt_log,
-              label='Peak Removed Spectrum', color='black')
+plot_spectra(fm.freqs, fm._spectrum_peak_rm, plt_log,
+             label='Peak Removed Spectrum', color='black')
 
 ###################################################################################################
 # Step 6: Re-fit the Aperiodic Component
@@ -206,10 +206,10 @@ plot_spectrum(fm.freqs, fm._spectrum_peak_rm, plt_log,
 
 # Plot the final aperiodic fit, calculated on the peak removed power spectrum
 _, ax = plt.subplots(figsize=(12, 10))
-plot_spectrum(fm.freqs, fm._spectrum_peak_rm, plt_log,
-              label='Peak Removed Spectrum', color='black', ax=ax)
-plot_spectrum(fm.freqs, fm._ap_fit, plt_log, label='Final Aperiodic Fit',
-              color='blue', alpha=0.5, linestyle='dashed', ax=ax)
+plot_spectra(fm.freqs, fm._spectrum_peak_rm, plt_log,
+             label='Peak Removed Spectrum', color='black', ax=ax)
+plot_spectra(fm.freqs, fm._ap_fit, plt_log, label='Final Aperiodic Fit',
+             color='blue', alpha=0.5, linestyle='dashed', ax=ax)
 
 ###################################################################################################
 # Step 7: Combine the Full Model Fit
@@ -226,8 +226,8 @@ plot_spectrum(fm.freqs, fm._ap_fit, plt_log, label='Final Aperiodic Fit',
 ###################################################################################################
 
 # Plot full model, created by combining the peak and aperiodic fits
-plot_spectrum(fm.freqs, fm.fooofed_spectrum_, plt_log,
-              label='Full Model', color='red')
+plot_spectra(fm.freqs, fm.fooofed_spectrum_, plt_log,
+             label='Full Model', color='red')
 
 ###################################################################################################
 #


### PR DESCRIPTION
This addresses a point in #193. `plot_spectra` not accepts 1d arrays and `plot_spectrum` has been replaced by `plot_spectra` throughout the module. The same has been done with `plot_spectra_shading`, with `plot_spectrum_shading` removed.

Also, `plot_spectrum` has been aliased to `plot_spectra` in the \_\_init\_\_.py to not break anyone's code. This wasn't done for `plot_spectrum_shading` since it's not imported in the init.