### PR TITLE
[ENH] Simplified saving kwargs

### DIFF
--- a/fooof/core/reports.py
+++ b/fooof/core/reports.py
@@ -1,6 +1,6 @@
 """Generate reports from FOOOF objects."""
 
-from fooof.core.io import fname, fpath
+from fooof.core.io import fname
 from fooof.core.modutils import safe_import, check_dependency
 from fooof.core.strings import gen_settings_str, gen_results_fm_str, gen_results_fg_str
 from fooof.plts.fg import plot_fg_ap, plot_fg_gf, plot_fg_peak_cens
@@ -22,7 +22,7 @@ SAVE_FORMAT = 'pdf'
 ###################################################################################################
 
 @check_dependency(plt, 'matplotlib')
-def save_report_fm(fm, file_name, file_path=None, plt_log=False):
+def save_report_fm(fm, file_name, plt_log=False):
     """Generate and save out a PDF report for a power spectrum model fit.
 
     Parameters
@@ -30,9 +30,7 @@ def save_report_fm(fm, file_name, file_path=None, plt_log=False):
     fm : FOOOF
         Object with results from fitting a power spectrum.
     file_name : str
-        Name to give the saved out file.
-    file_path : str, optional
-        Path to directory to save to. If None, saves to current directory.
+        Name of output file to save, including absolute or relative path.
     plt_log : bool, optional, default: False
         Whether or not to plot the frequency axis in log space.
     """
@@ -62,12 +60,12 @@ def save_report_fm(fm, file_name, file_path=None, plt_log=False):
     ax2.set_yticks([])
 
     # Save out the report
-    plt.savefig(fpath(file_path, fname(file_name, SAVE_FORMAT)))
+    plt.savefig(fname(file_name, SAVE_FORMAT))
     plt.close()
 
 
 @check_dependency(plt, 'matplotlib')
-def save_report_fg(fg, file_name, file_path=None):
+def save_report_fg(fg, file_name):
     """Generate and save out a PDF report for a group of power spectrum models.
 
     Parameters
@@ -75,9 +73,7 @@ def save_report_fg(fg, file_name, file_path=None):
     fg : FOOOFGroup
         Object with results from fitting a group of power spectra.
     file_name : str
-        Name to give the saved out file.
-    file_path : str, optional
-        Path to directory to save to. If None, saves to current directory.
+        Name of output file to save, including absolute or relative path.
     """
 
     # Initialize figure
@@ -105,5 +101,5 @@ def save_report_fg(fg, file_name, file_path=None):
     plot_fg_peak_cens(fg, ax3)
 
     # Save out the report
-    plt.savefig(fpath(file_path, fname(file_name, SAVE_FORMAT)))
+    plt.savefig(fname(file_name, SAVE_FORMAT))
     plt.close()

--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -633,38 +633,34 @@ class FOOOF():
 
 
     @copy_doc_func_to_method(plot_fm)
-    def plot(self, plot_peaks=None, plot_aperiodic=True, plt_log=False,
-             add_legend=True, save_fig=False, file_name=None, file_path=None,
-             ax=None, plot_style=style_spectrum_plot,
-             data_kwargs=None, model_kwargs=None, aperiodic_kwargs=None, peak_kwargs=None):
+    def plot(self, plot_peaks=None, plot_aperiodic=True, plt_log=False, add_legend=True,
+             file_name=None, ax=None, plot_style=style_spectrum_plot, data_kwargs=None,
+             model_kwargs=None, aperiodic_kwargs=None, peak_kwargs=None):
 
-        plot_fm(self, plot_peaks, plot_aperiodic, plt_log, add_legend,
-                save_fig, file_name, file_path, ax, plot_style,
-                data_kwargs, model_kwargs, aperiodic_kwargs, peak_kwargs)
+        plot_fm(self, plot_peaks, plot_aperiodic, plt_log, add_legend, file_name, ax,
+                plot_style, data_kwargs, model_kwargs, aperiodic_kwargs, peak_kwargs)
 
 
     @copy_doc_func_to_method(save_report_fm)
-    def save_report(self, file_name, file_path=None, plt_log=False):
+    def save_report(self, file_name, plt_log=False):
 
-        save_report_fm(self, file_name, file_path, plt_log)
+        save_report_fm(self, file_name, plt_log)
 
 
     @copy_doc_func_to_method(save_fm)
-    def save(self, file_name, file_path=None, append=False,
+    def save(self, file_name, append=False,
              save_results=False, save_settings=False, save_data=False):
 
-        save_fm(self, file_name, file_path, append, save_results, save_settings, save_data)
+        save_fm(self, file_name, append, save_results, save_settings, save_data)
 
 
-    def load(self, file_name, file_path=None, regenerate=True):
+    def load(self, file_name, regenerate=True):
         """Load in a FOOOF formatted JSON file to the current object.
 
         Parameters
         ----------
         file_name : str or FileObject
-            File to load data from.
-        file_path : str or None, optional
-            Path to directory to load from. If None, loads from current directory.
+            File to load data from, including absolute or relative path.
         regenerate : bool, optional, default: True
             Whether to regenerate the model fit from the loaded data, if data is available.
         """
@@ -673,7 +669,7 @@ class FOOOF():
         self._reset_data_results(True, True, True)
 
         # Load JSON file, add to self and check loaded data
-        data = load_json(file_name, file_path)
+        data = load_json(file_name)
         self._add_from_dict(data)
         self._check_loaded_settings(data)
         self._check_loaded_results(data)

--- a/fooof/objs/group.py
+++ b/fooof/objs/group.py
@@ -398,40 +398,38 @@ class FOOOFGroup(FOOOF):
 
 
     @copy_doc_func_to_method(plot_fg)
-    def plot(self, save_fig=False, file_name=None, file_path=None):
+    def plot(self, file_name=None):
 
-        plot_fg(self, save_fig, file_name, file_path)
+        plot_fg(self, file_name)
 
 
     @copy_doc_func_to_method(save_report_fg)
-    def save_report(self, file_name, file_path=None):
+    def save_report(self, file_name):
 
-        save_report_fg(self, file_name, file_path)
+        save_report_fg(self, file_name)
 
 
     @copy_doc_func_to_method(save_fg)
-    def save(self, file_name, file_path=None, append=False,
+    def save(self, file_name, append=False,
              save_results=False, save_settings=False, save_data=False):
 
-        save_fg(self, file_name, file_path, append, save_results, save_settings, save_data)
+        save_fg(self, file_name, append, save_results, save_settings, save_data)
 
 
-    def load(self, file_name, file_path=None):
+    def load(self, file_name):
         """Load FOOOFGroup data from file.
 
         Parameters
         ----------
         file_name : str
-            File to load data from.
-        file_path : str, optional
-            Path to directory to load from. If None, loads from current directory.
+            File to load data from, including absolute or relative path.
         """
 
         # Clear results so as not to have possible prior results interfere
         self._reset_group_results()
 
         power_spectra = []
-        for ind, data in enumerate(load_jsonlines(file_name, file_path)):
+        for ind, data in enumerate(load_jsonlines(file_name)):
 
             self._add_from_dict(data)
 

--- a/fooof/plts/fg.py
+++ b/fooof/plts/fg.py
@@ -5,7 +5,7 @@ Notes
 This file contains plotting functions that take as input a FOOOFGroup object.
 """
 
-from fooof.core.io import fname, fpath
+from fooof.core.io import fname
 from fooof.core.errors import NoModelError
 from fooof.core.modutils import safe_import, check_dependency
 from fooof.plts.settings import PLT_FIGSIZES
@@ -18,19 +18,15 @@ gridspec = safe_import('.gridspec', 'matplotlib')
 ###################################################################################################
 
 @check_dependency(plt, 'matplotlib')
-def plot_fg(fg, save_fig=False, file_name=None, file_path=None):
+def plot_fg(fg, file_name=None):
     """Plot a figure with subplots visualizing the parameters from a FOOOFGroup object.
 
     Parameters
     ----------
     fg : FOOOFGroup
         Object containing results from fitting a group of power spectra.
-    save_fig : bool, optional, default: False
-        Whether to save out a copy of the plot.
-    file_name : str, optional
-        Name to give the saved out file.
-    file_path : str, optional
-        Path to directory to save to. If None, saves to current directory.
+    file_name : str, optional, default: None
+        Name with format to save as, including absolute or relative path.
 
     Raises
     ------
@@ -56,10 +52,8 @@ def plot_fg(fg, save_fig=False, file_name=None, file_path=None):
     ax2 = plt.subplot(gs[1, :])
     plot_fg_peak_cens(fg, ax2)
 
-    if save_fig:
-        if not file_name:
-            raise ValueError("Input 'file_name' is required to save out the plot.")
-        plt.savefig(fpath(file_path, fname(file_name, 'png')))
+    if file_name is not None:
+        plt.savefig(fname(file_name, 'png'))
 
 
 @check_dependency(plt, 'matplotlib')

--- a/fooof/plts/fm.py
+++ b/fooof/plts/fm.py
@@ -7,7 +7,7 @@ This file contains plotting functions that take as input a FOOOF object.
 
 import numpy as np
 
-from fooof.core.io import fname, fpath
+from fooof.core.io import fname
 from fooof.core.utils import nearest_ind
 from fooof.core.modutils import safe_import, check_dependency
 from fooof.sim.gen import gen_periodic
@@ -25,8 +25,7 @@ plt = safe_import('.pyplot', 'matplotlib')
 
 @check_dependency(plt, 'matplotlib')
 def plot_fm(fm, plot_peaks=None, plot_aperiodic=True, plt_log=False, add_legend=True,
-            save_fig=False, file_name=None, file_path=None,
-            ax=None, plot_style=style_spectrum_plot,
+            file_name=None, ax=None, plot_style=style_spectrum_plot,
             data_kwargs=None, model_kwargs=None, aperiodic_kwargs=None, peak_kwargs=None):
     """Plot the power spectrum and model fit results from a FOOOF object.
 
@@ -43,13 +42,9 @@ def plot_fm(fm, plot_peaks=None, plot_aperiodic=True, plt_log=False, add_legend=
         Whether to plot the frequency values in log10 spacing.
     add_legend : boolean, optional, default: False
         Whether to add a legend describing the plot components.
-    save_fig : bool, optional, default: False
-        Whether to save out a copy of the plot.
-    file_name : str, optional
-        Name to give the saved out file.
-    file_path : str, optional
-        Path to directory to save to. If None, saves to current directory.
-    ax : matplotlib.Axes, optional
+    file_name : str, optional, default: None
+        Name with format to save as, including absolute or relative path.
+    ax : matplotlib.Axes, optional, default: None
         Figure axes upon which to plot.
     plot_style : callable, optional, default: style_spectrum_plot
         A function to call to apply styling & aesthetics to the plot.
@@ -100,10 +95,8 @@ def plot_fm(fm, plot_peaks=None, plot_aperiodic=True, plt_log=False, add_legend=
     check_n_style(plot_style, ax, log_freqs, True)
 
     # Save out figure, if requested
-    if save_fig:
-        if not file_name:
-            raise ValueError("Input 'file_name' is required to save out the plot.")
-        plt.savefig(fpath(file_path, fname(file_name, 'png')))
+    if file_name is not None:
+        plt.savefig(fname(file_name, 'png'))
 
 
 def _add_peaks(fm, approach, plt_log, ax, peak_kwargs):

--- a/fooof/tests/core/test_io.py
+++ b/fooof/tests/core/test_io.py
@@ -21,43 +21,38 @@ def test_fname():
     assert fname('report.pdf', 'pdf') == 'report.pdf'
     assert fname('report.png', 'pdf') == 'report.png'
 
-def test_fpath():
-    """Check that the file path checker helper function properly checks / combines file paths."""
-
-    assert fpath(None, 'data.json') == 'data.json'
-    assert fpath('/path/', 'data.json') == '/path/data.json'
 
 def test_save_fm_str(tfm):
     """Check saving fm data, with file specifiers as strings."""
 
     # Test saving out each set of save elements
-    file_name_res = 'test_fooof_res'
-    file_name_set = 'test_fooof_set'
-    file_name_dat = 'test_fooof_dat'
+    file_name_res = os.path.join(TEST_DATA_PATH, 'test_fooof_res')
+    file_name_set = os.path.join(TEST_DATA_PATH,'test_fooof_set')
+    file_name_dat = os.path.join(TEST_DATA_PATH,'test_fooof_dat')
 
-    save_fm(tfm, file_name_res, TEST_DATA_PATH, False, True, False, False)
-    save_fm(tfm, file_name_set, TEST_DATA_PATH, False, False, True, False)
-    save_fm(tfm, file_name_dat, TEST_DATA_PATH, False, False, False, True)
+    save_fm(tfm, file_name_res, False, True, False, False)
+    save_fm(tfm, file_name_set, False, False, True, False)
+    save_fm(tfm, file_name_dat, False, False, False, True)
 
-    assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name_res + '.json'))
-    assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name_set + '.json'))
-    assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name_dat + '.json'))
+    assert os.path.exists(file_name_res + '.json')
+    assert os.path.exists(file_name_set + '.json')
+    assert os.path.exists(file_name_dat + '.json')
 
     # Test saving out all save elements
-    file_name_all = 'test_fooof_all'
-    save_fm(tfm, file_name_all, TEST_DATA_PATH, False, True, True, True)
-    assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name_all + '.json'))
+    file_name_all = os.path.join(TEST_DATA_PATH, 'test_fooof_all')
+    save_fm(tfm, file_name_all, False, True, True, True)
+    assert os.path.exists(file_name_all + '.json')
 
 
 def test_save_fm_append(tfm):
     """Check saving fm data, appending to a file."""
 
-    file_name = 'test_fooof_append'
+    file_name = os.path.join(TEST_DATA_PATH, 'test_fooof_append')
 
-    save_fm(tfm, file_name, TEST_DATA_PATH, True, True, True, True)
-    save_fm(tfm, file_name, TEST_DATA_PATH, True, True, True, True)
+    save_fm(tfm, file_name, True, True, True, True)
+    save_fm(tfm, file_name, True, True, True, True)
 
-    assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name + '.json'))
+    assert os.path.exists(file_name + '.json')
 
 def test_save_fm_fobj(tfm):
     """Check saving fm data, with file object file specifier."""
@@ -66,41 +61,41 @@ def test_save_fm_fobj(tfm):
 
     # Save, using file-object: three successive lines with three possible save settings
     with open(os.path.join(TEST_DATA_PATH, file_name + '.json'), 'w') as f_obj:
-        save_fm(tfm, f_obj, TEST_DATA_PATH, False, True, False, False)
-        save_fm(tfm, f_obj, TEST_DATA_PATH, False, False, True, False)
-        save_fm(tfm, f_obj, TEST_DATA_PATH, False, False, False, True)
+        save_fm(tfm, f_obj, False, True, False, False)
+        save_fm(tfm, f_obj, False, False, True, False)
+        save_fm(tfm, f_obj, False, False, False, True)
 
     assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name + '.json'))
 
 def test_save_fg(tfg):
     """Check saving fg data."""
 
-    res_file_name = 'test_fooofgroup_res'
-    set_file_name = 'test_fooofgroup_set'
-    dat_file_name = 'test_fooofgroup_dat'
+    res_file_name = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_res')
+    set_file_name = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_set')
+    dat_file_name = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_dat')
 
-    save_fg(tfg, file_name=res_file_name, file_path=TEST_DATA_PATH, save_results=True)
-    save_fg(tfg, file_name=set_file_name, file_path=TEST_DATA_PATH, save_settings=True)
-    save_fg(tfg, file_name=dat_file_name, file_path=TEST_DATA_PATH, save_data=True)
+    save_fg(tfg, file_name=res_file_name, save_results=True)
+    save_fg(tfg, file_name=set_file_name, save_settings=True)
+    save_fg(tfg, file_name=dat_file_name, save_data=True)
 
-    assert os.path.exists(os.path.join(TEST_DATA_PATH, res_file_name + '.json'))
-    assert os.path.exists(os.path.join(TEST_DATA_PATH, set_file_name + '.json'))
-    assert os.path.exists(os.path.join(TEST_DATA_PATH, dat_file_name + '.json'))
+    assert os.path.exists(res_file_name + '.json')
+    assert os.path.exists(set_file_name + '.json')
+    assert os.path.exists(dat_file_name + '.json')
 
     # Test saving out all save elements
     file_name_all = 'test_fooofgroup_all'
-    save_fg(tfg, file_name_all, TEST_DATA_PATH, False, True, True, True)
+    save_fg(tfg, os.path.join(TEST_DATA_PATH, file_name_all), False, True, True, True)
     assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name_all + '.json'))
 
 def test_save_fg_append(tfg):
     """Check saving fg data, appending to file."""
 
-    file_name = 'test_fooofgroup_append'
+    file_name = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_append')
 
-    save_fg(tfg, file_name, TEST_DATA_PATH, True, save_results=True)
-    save_fg(tfg, file_name, TEST_DATA_PATH, True, save_results=True)
+    save_fg(tfg, file_name, True, save_results=True)
+    save_fg(tfg, file_name, True, save_results=True)
 
-    assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name + '.json'))
+    assert os.path.exists(file_name + '.json')
 
 def test_save_fg_fobj(tfg):
     """Check saving fg data, with file object file specifier."""
@@ -108,7 +103,7 @@ def test_save_fg_fobj(tfg):
     file_name = 'test_fooof_fileobj'
 
     with open(os.path.join(TEST_DATA_PATH, file_name + '.json'), 'w') as f_obj:
-        save_fg(tfg, f_obj, TEST_DATA_PATH, False, True, False, False)
+        save_fg(tfg, f_obj, False, True, False, False)
 
     assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name + '.json'))
 
@@ -117,9 +112,9 @@ def test_load_json_str():
     Loads files from test_save_fm_str.
     """
 
-    file_name = 'test_fooof_all'
+    file_name = os.path.join(TEST_DATA_PATH, 'test_fooof_all')
 
-    data = load_json(file_name, TEST_DATA_PATH)
+    data = load_json(file_name)
 
     assert data
 
@@ -128,10 +123,10 @@ def test_load_json_fobj():
     Loads files from test_save_fm_str.
     """
 
-    file_name = 'test_fooof_all'
+    file_name = os.path.join(TEST_DATA_PATH, 'test_fooof_all')
 
-    with open(os.path.join(TEST_DATA_PATH, file_name + '.json'), 'r') as f_obj:
-        data = load_json(f_obj, '')
+    with open(file_name + '.json', 'r') as f_obj:
+        data = load_json(f_obj)
 
     assert data
 
@@ -140,9 +135,9 @@ def test_load_jsonlines():
     Loads files from test_save_fg.
     """
 
-    res_file_name = 'test_fooofgroup_res'
+    res_file_name = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_res')
 
-    for data in load_jsonlines(res_file_name, TEST_DATA_PATH):
+    for data in load_jsonlines(res_file_name):
         assert data
 
 def test_load_file_contents():
@@ -150,8 +145,8 @@ def test_load_file_contents():
     Note that is this test fails, it likely stems from an issue from saving.
     """
 
-    file_name = 'test_fooof_all'
-    loaded_data = load_json(file_name, TEST_DATA_PATH)
+    file_name = os.path.join(TEST_DATA_PATH, 'test_fooof_all')
+    loaded_data = load_json(file_name)
 
     # Check settings
     for setting in OBJ_DESC['settings']:

--- a/fooof/tests/core/test_reports.py
+++ b/fooof/tests/core/test_reports.py
@@ -11,16 +11,16 @@ from fooof.core.reports import *
 
 def test_save_report_fm(tfm, skip_if_no_mpl):
 
-    file_name = 'test_report'
+    file_name = os.path.join(TEST_REPORTS_PATH, 'test_report')
 
-    save_report_fm(tfm, file_name, TEST_REPORTS_PATH)
+    save_report_fm(tfm, file_name)
 
     assert os.path.exists(os.path.join(TEST_REPORTS_PATH, file_name + '.pdf'))
 
 def test_save_report_fg(tfg, skip_if_no_mpl):
 
-    file_name = 'test_group_report'
+    file_name = os.path.join(TEST_REPORTS_PATH, 'test_group_report')
 
-    save_report_fg(tfg, file_name, TEST_REPORTS_PATH)
+    save_report_fg(tfg, file_name)
 
-    assert os.path.exists(os.path.join(TEST_REPORTS_PATH, file_name + '.pdf'))
+    assert os.path.exists(file_name + '.pdf')

--- a/fooof/tests/objs/test_fit.py
+++ b/fooof/tests/objs/test_fit.py
@@ -6,6 +6,7 @@ The tests here are not strong tests for accuracy.
 They serve rather as 'smoke tests', for if anything fails completely.
 """
 
+import os
 import numpy as np
 from py.test import raises
 
@@ -179,8 +180,8 @@ def test_fooof_load():
 
     # Test loading just results
     tfm = FOOOF(verbose=False)
-    file_name_res = 'test_fooof_res'
-    tfm.load(file_name_res, TEST_DATA_PATH)
+    file_name_res = os.path.join(TEST_DATA_PATH, 'test_fooof_res')
+    tfm.load(file_name_res)
     # Check that result attributes get filled
     for result in OBJ_DESC['results']:
         assert not np.all(np.isnan(getattr(tfm, result)))
@@ -193,8 +194,8 @@ def test_fooof_load():
 
     # Test loading just settings
     tfm = FOOOF(verbose=False)
-    file_name_set = 'test_fooof_set'
-    tfm.load(file_name_set, TEST_DATA_PATH)
+    file_name_set = os.path.join(TEST_DATA_PATH, 'test_fooof_set')
+    tfm.load(file_name_set)
     for setting in OBJ_DESC['settings']:
         assert getattr(tfm, setting) is not None
     # Test that results and data are None
@@ -204,8 +205,8 @@ def test_fooof_load():
 
     # Test loading just data
     tfm = FOOOF(verbose=False)
-    file_name_dat = 'test_fooof_dat'
-    tfm.load(file_name_dat, TEST_DATA_PATH)
+    file_name_dat = os.path.join(TEST_DATA_PATH, 'test_fooof_dat')
+    tfm.load(file_name_dat)
     assert tfm.power_spectrum is not None
     # Test that settings and results are None
     for setting in OBJ_DESC['settings']:
@@ -215,8 +216,8 @@ def test_fooof_load():
 
     # Test loading all elements
     tfm = FOOOF(verbose=False)
-    file_name_all = 'test_fooof_all'
-    tfm.load(file_name_all, TEST_DATA_PATH)
+    file_name_all = os.path.join(TEST_DATA_PATH, 'test_fooof_all')
+    tfm.load(file_name_all)
     for result in OBJ_DESC['results']:
         assert not np.all(np.isnan(getattr(tfm, result)))
     for setting in OBJ_DESC['settings']:

--- a/fooof/tests/objs/test_group.py
+++ b/fooof/tests/objs/test_group.py
@@ -6,6 +6,7 @@ The tests here are not strong tests for accuracy.
 They serve rather as 'smoke tests', for if anything fails completely.
 """
 
+import os
 import numpy as np
 from numpy.testing import assert_equal
 
@@ -236,13 +237,13 @@ def test_fg_plot(tfg, skip_if_no_mpl):
 def test_fg_load():
     """Test load into FOOOFGroup. Note: loads files from test_core_io."""
 
-    file_name_res = 'test_fooofgroup_res'
-    file_name_set = 'test_fooofgroup_set'
-    file_name_dat = 'test_fooofgroup_dat'
+    file_name_res = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_res')
+    file_name_set = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_set')
+    file_name_dat = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_dat')
 
     # Test loading just results
     tfg = FOOOFGroup(verbose=False)
-    tfg.load(file_name_res, TEST_DATA_PATH)
+    tfg.load(file_name_res)
     assert len(tfg.group_results) > 0
     # Test that settings and data are None
     #   Except for aperiodic mode, which can be inferred from the data
@@ -253,7 +254,7 @@ def test_fg_load():
 
     # Test loading just settings
     tfg = FOOOFGroup(verbose=False)
-    tfg.load(file_name_set, TEST_DATA_PATH)
+    tfg.load(file_name_set)
     for setting in OBJ_DESC['settings']:
         assert getattr(tfg, setting) is not None
     # Test that results and data are None
@@ -263,7 +264,7 @@ def test_fg_load():
 
     # Test loading just data
     tfg = FOOOFGroup(verbose=False)
-    tfg.load(file_name_dat, TEST_DATA_PATH)
+    tfg.load(file_name_dat)
     assert tfg.power_spectra is not None
     # Test that settings and results are None
     for setting in OBJ_DESC['settings']:
@@ -273,8 +274,8 @@ def test_fg_load():
 
     # Test loading all elements
     tfg = FOOOFGroup(verbose=False)
-    file_name_all = 'test_fooofgroup_all'
-    tfg.load(file_name_all, TEST_DATA_PATH)
+    file_name_all = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_all')
+    tfg.load(file_name_all)
     assert len(tfg.group_results) > 0
     for setting in OBJ_DESC['settings']:
         assert getattr(tfg, setting) is not None

--- a/fooof/tests/utils/test_io.py
+++ b/fooof/tests/utils/test_io.py
@@ -1,5 +1,6 @@
 """Test functions for fooof.utils.io."""
 
+import os
 import numpy as np
 
 from fooof.core.items import OBJ_DESC
@@ -14,9 +15,9 @@ from fooof.utils.io import *
 
 def test_load_fooof():
 
-    file_name = 'test_fooof_all'
+    file_name = os.path.join(TEST_DATA_PATH, 'test_fooof_all')
 
-    tfm = load_fooof(file_name, TEST_DATA_PATH)
+    tfm = load_fooof(file_name)
 
     assert isinstance(tfm, FOOOF)
 
@@ -32,8 +33,8 @@ def test_load_fooof():
 
 def test_load_fooofgroup():
 
-    file_name = 'test_fooofgroup_all'
-    tfg = load_fooofgroup(file_name, TEST_DATA_PATH)
+    file_name = os.path.join(TEST_DATA_PATH, 'test_fooofgroup_all')
+    tfg = load_fooofgroup(file_name)
 
     assert isinstance(tfg, FOOOFGroup)
 

--- a/fooof/utils/io.py
+++ b/fooof/utils/io.py
@@ -3,15 +3,13 @@
 ###################################################################################################
 ###################################################################################################
 
-def load_fooof(file_name, file_path=None, regenerate=True):
+def load_fooof(file_name, regenerate=True):
     """Load a FOOOF file into a FOOOF object.
 
     Parameters
     ----------
     file_name : str or FileObject
-        File to load the data from.
-    file_path : str or None, optional
-        Path to directory to load from. If None, loads from current directory.
+        File to load the data from, including absolute or relative path.
     regenerate : bool, optional, default: True
         Whether to regenerate the model fit from the loaded data, if data is available.
 
@@ -26,20 +24,18 @@ def load_fooof(file_name, file_path=None, regenerate=True):
     fm = FOOOF()
 
     # Load data into object
-    fm.load(file_name, file_path, regenerate)
+    fm.load(file_name, regenerate)
 
     return fm
 
 
-def load_fooofgroup(file_name, file_path=None):
+def load_fooofgroup(file_name):
     """Load data from file into a FOOOFGroup object.
 
     Parameters
     ----------
     file_name : str
-        File to load data data.
-    file_path : str, optional
-        Path to directory to load from. If None, loads from current directory.
+        File to load data data, including absolute or relative path.
 
     Returns
     -------
@@ -52,6 +48,6 @@ def load_fooofgroup(file_name, file_path=None):
     fg = FOOOFGroup()
 
     # Load data into object
-    fg.load(file_name, file_path)
+    fg.load(file_name)
 
     return fg


### PR DESCRIPTION
Addresses a point in #193. This reduces `save_fig`, `file_name`, and `file_path` when saving plots and `file_name` and `file_path` when saving reports, to only `file_path`. This is in-line with most packages (numpy, scipy, pandas, sklearn, etc) only having one argument to specify both file name and path when saving objects.

Here is a example with relative/abosolute paths with one `file_path` arg:

```python
import os
import shutil
from fooof import FOOOF, FOOOFGroup
from fooof.sim import gen_group_power_spectra

# Simulate
freqs, powers = gen_group_power_spectra(10, (1, 50), [-2, 0], [10, 5, 5])

# Fit
fm = FOOOF(verbose=False)
fm.fit(freqs, powers[0])

fg = FOOOFGroup(verbose=False)
fg.fit(freqs, powers)

# Make a tmp directory
if os.path.isdir('tmpdir_'):
    shutil.rmtree('tmpdir_')
os.mkdir('tmpdir_')

# Relative Path
fm.plot(file_name='tmpdir_/plot')
fm.save(file_name='tmpdir_/results')
fm.save_report(file_name='tmpdir_/report')

fg.plot(file_name='tmpdir_/fg_plot')
fg.save(file_name='tmpdir_/fg_results', save_results=True)
fg.save_report(file_name='tmpdir_/fg_report')

assert os.path.isfile('tmpdir_/plot.png')
assert os.path.isfile('tmpdir_/results.json')
assert os.path.isfile('tmpdir_/report.pdf')
assert os.path.isfile('tmpdir_/fg_plot.png')
assert os.path.isfile('tmpdir_/fg_results.json')
assert os.path.isfile('tmpdir_/fg_report.pdf')

# Absolute Path
cwd = os.getcwd()

fm.plot(file_name=cwd + '/tmpdir_/plot')
fm.save(file_name=cwd + '/tmpdir_/results')
fm.save_report(file_name=cwd + '/tmpdir_/report')

fg.plot(file_name=cwd + '/tmpdir_/fg_plot')
fg.save(file_name=cwd + '/tmpdir_/fg_results', save_results=True)
fg.save_report(file_name=cwd + '/tmpdir_/fg_report')

assert os.path.isfile(cwd + '/tmpdir_/plot.png')
assert os.path.isfile(cwd + '/tmpdir_/results.json')
assert os.path.isfile(cwd + '/tmpdir_/report.pdf')
assert os.path.isfile(cwd + '/tmpdir_/fg_plot.png')
assert os.path.isfile(cwd + '/tmpdir_/fg_results.json')
assert os.path.isfile(cwd + '/tmpdir_/fg_report.pdf')

shutil.rmtree('tmpdir_')
```
