### PR TITLE
[BUG] - Fix embedded lists for ap_fit guess

### DIFF
--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -751,7 +751,7 @@ class FOOOF():
             else tuple(bound[0::2] for bound in self._ap_bounds)
 
         # Collect together guess parameters
-        guess = np.array([off_guess + kne_guess + exp_guess])
+        guess = np.array(off_guess + kne_guess + exp_guess)
 
         # Ignore warnings that are raised in curve_fit
         #   A runtime warning can occur while exploring parameters in curve fitting


### PR DESCRIPTION
Short version: the fixed line ended up with an extra layer of embedded lists which led to downstream problems. 

The longer version (why it's a problem):
In practice, we never bound the aperiodic fits, but in theory one could, by update `_ap_bounds`. However - if one tried to do this, then the fitting actually gets kicked to a different approach, which then checks that the guess parameters are 1d. This would then fail, because the embedded list made them 2d. This PR fixes that.

Note that this change doesn't change anything that happens in standard usage - but will make it possible to add `_ap_bounds`, in which case what happens in the fitting is slightly different. 