### PR TITLE
[BUG] - Fix estimation of the exponent guess

### DIFF
--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -742,8 +742,8 @@ class FOOOF():
         #   Note that these are collected as lists, to concatenate with or without knee later
         off_guess = [power_spectrum[0] if not self._ap_guess[0] else self._ap_guess[0]]
         kne_guess = [self._ap_guess[1]] if self.aperiodic_mode == 'knee' else []
-        exp_guess = [np.abs(self.power_spectrum[-1] - self.power_spectrum[0] /
-                            np.log10(self.freqs[-1]) - np.log10(self.freqs[0]))
+        exp_guess = [np.abs((self.power_spectrum[-1] - self.power_spectrum[0]) /
+                            (np.log10(self.freqs[-1]) - np.log10(self.freqs[0])))
                      if not self._ap_guess[2] else self._ap_guess[2]]
 
         # Get bounds for aperiodic fitting, dropping knee bound if not set to fit knee


### PR DESCRIPTION
Someone emailed to point out that the guess exponent estimation, line 745 of fit, looks to have missing parentheses. What should be `[abs((a-b) / (c-d))]` was actually `[abs( a - b / c - d )]`, meaning the calculated value is wrong (is not the slope estimate we want it to be. This fixes that. 

Note that the exponent guess is just an initial value into curve_fit. In all my checks on this, fixing this makes literally zero difference to the model solution - so this shouldn't impact any fits in practice. 