### PR TITLE
[BUG] Annotated Plots

### DIFF
--- a/fooof/plts/annotate.py
+++ b/fooof/plts/annotate.py
@@ -41,6 +41,9 @@ def plot_annotated_peak_search(fm):
     # Calculate ylims of the plot that are scaled to the range of the data
     ylims = [min(flatspec) - 0.1 * np.abs(min(flatspec)), max(flatspec) + 0.1 * max(flatspec)]
 
+    # Sort parameters by peak height
+    gaussian_params = fm.gaussian_params_[fm.gaussian_params_[:, 1].argsort()][::-1]
+
     # Loop through the iterative search for each peak
     for ind in range(fm.n_peaks_ + 1):
 
@@ -63,7 +66,7 @@ def plot_annotated_peak_search(fm):
 
         if ind < fm.n_peaks_:
 
-            gauss = gaussian_function(fm.freqs, *fm.gaussian_params_[ind, :])
+            gauss = gaussian_function(fm.freqs, *gaussian_params[ind, :])
             plot_spectra(fm.freqs, gauss, ax=ax, label='Gaussian Fit',
                          color=PLT_COLORS['periodic'], linestyle=':', linewidth=3.0)
 


### PR DESCRIPTION
Iterations in annotated plots are currently plotted by by ascending center frequency, rather than descending peak height (i.e. the order of the peak search). Someone emailed confused about this. I've fixed it here.

Before:
![peak_search](https://user-images.githubusercontent.com/34786005/117513553-d15c7100-af46-11eb-88b1-61ff9143148e.png)

After:
![peak_search_fix](https://user-images.githubusercontent.com/34786005/117513575-dae5d900-af46-11eb-8e17-356ac74ee070.png)
