### PR TITLE
[BUG] - Fix return in check_dependency

### DIFF
--- a/fooof/core/modutils.py
+++ b/fooof/core/modutils.py
@@ -177,6 +177,6 @@ def check_dependency(dep, name):
             if not dep:
                 raise ImportError("Optional FOOOF dependency " + name + \
                                   " is required for this functionality.")
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
         return wrapped_func
     return wrap


### PR DESCRIPTION
There was a bug in `check_dependency` that wouldn't return the outputs of the returned function. Within specparam, this never really came up, since we use this for plot functions (with no returns). Therefore, this fix makes the function do what it is supposed to do - but should currently have no impact on anything already using `check_dependency` within the module. 