### PR TITLE
Fix brittle flaky tests in core/test_io.py

### DIFF
--- a/fooof/tests/core/test_io.py
+++ b/fooof/tests/core/test_io.py
@@ -112,45 +112,49 @@ def test_save_fg_fobj(tfg):
 
     assert os.path.exists(os.path.join(TEST_DATA_PATH, file_name + '.json'))
 
-def test_load_json_str():
+def test_load_json_str(tfm):
     """Test loading JSON file, with str file specifier.
     Loads files from test_save_fm_str.
     """
 
     file_name = 'test_fooof_all'
+    test_save_fm_str(tfm)
 
     data = load_json(file_name, TEST_DATA_PATH)
 
     assert data
 
-def test_load_json_fobj():
+def test_load_json_fobj(tfm):
     """Test loading JSON file, with file object file specifier.
     Loads files from test_save_fm_str.
     """
 
     file_name = 'test_fooof_all'
+    test_save_fm_str(tfm)
 
     with open(os.path.join(TEST_DATA_PATH, file_name + '.json'), 'r') as f_obj:
         data = load_json(f_obj, '')
 
     assert data
 
-def test_load_jsonlines():
+def test_load_jsonlines(tfg):
     """Test loading JSONlines file.
     Loads files from test_save_fg.
     """
 
     res_file_name = 'test_fooofgroup_res'
+    test_save_fg(tfg)
 
     for data in load_jsonlines(res_file_name, TEST_DATA_PATH):
         assert data
 
-def test_load_file_contents():
+def test_load_file_contents(tfm):
     """Check that loaded files contain the contents they should.
     Note that is this test fails, it likely stems from an issue from saving.
     """
 
     file_name = 'test_fooof_all'
+    test_load_json_str(tfm)
     loaded_data = load_json(file_name, TEST_DATA_PATH)
 
     # Check settings


### PR DESCRIPTION
Four of the tests inside the `fooof/tests/core/test_io.py` module were found to be flaky (specifically, something called brittle flakiness), when using the [pytest-flakefinder](https://github.com/dropbox/pytest-flakefinder) plugin. A flaky test is a test that both passes and fails despite no changes to the code or the test itself. Brittle flakiness (defined as per [iFixFlakies](https://mir.cs.illinois.edu/winglam/publications/2019/ShiETAL19iFixFlakies.pdf)) is when a test runs fine when run in conjunction with the other tests in the same module but fails when run on its own. 

To reproduce: 

`pytest fooof/tests/core/test_io.py::test_load_json_str`
`pytest fooof/tests/core/test_io.py::test_load_json_fobj`
`pytest fooof/tests/core/test_io.py::test_load_jsonlines`
`pytest fooof/tests/core/test_io.py::test_load_file_contents`

All other tests inside `test_io.py` ran fine when run on their own. But when the tests above were run on their own, they failed, due to some files not existing. When the entire module is run, this behavior is not seen. To fix, I just added the appropriate function calls which creates the JSON files required by the tests above.

I'm aware that the tests might not be run on their own, but this makes the entire module more robust so it's just a small fix for you to consider.

NOTE: This PR contains similar changes to my previously opened [PR](https://github.com/fooof-tools/fooof/pull/242). The difference is that the tests in this PR were from a different module and were found at a later time.