### PR TITLE
add deprecation warning

### DIFF
--- a/fooof/__init__.py
+++ b/fooof/__init__.py
@@ -2,15 +2,15 @@
 
 from .version import __version__
 
-# deprecation of fooof for specparam
+# Deprecation of fooof / move to specparam message
+#   Note: this warning is for fooof v1.1 specifically, and should be removed in specparam 2.0
 from warnings import warn, simplefilter
-simplefilter('always') # make sure user sees it once, on every import
-warn_text = 'Warning: The fooof package is being deprecated in favor of the\
- spectral parameterization (specparam) package. This version of fooof is\
- functional, however we recommend upgrading to specparam, because this 1.1\
- version of fooof will not have continuing development. All new features and\
- development will be done on the specparam package.'
-warn(warn_text, DeprecationWarning, stacklevel=2)
+simplefilter('always')  # make sure user sees it once, on every import
+DEPRECATION_TEXT = ("\nThe `fooof` package is being deprecated and replaced by the "
+    "`specparam` (spectral parameterization) package."
+    "\nThis version of `fooof` (1.1) is fully functional, but will not be further updated."
+    "\nNew projects are recommended to update to using `specparam` (see Changelog for details).")
+warn(DEPRECATION_TEXT, DeprecationWarning, stacklevel=2)
 
 from .bands import Bands
 from .objs import FOOOF, FOOOFGroup

--- a/fooof/__init__.py
+++ b/fooof/__init__.py
@@ -2,6 +2,16 @@
 
 from .version import __version__
 
+# deprecation of fooof for specparam
+from warnings import warn, simplefilter
+simplefilter('always') # make sure user sees it once, on every import
+warn_text = 'Warning: The fooof package is being deprecated in favor of the\
+ spectral parameterization (specparam) package. This version of fooof is\
+ functional, however we recommend upgrading to specparam, because this 1.1\
+ version of fooof will not have continuing development. All new features and\
+ development will be done on the specparam package.'
+warn(warn_text, DeprecationWarning, stacklevel=2)
+
 from .bands import Bands
 from .objs import FOOOF, FOOOFGroup
 from .objs.utils import fit_fooof_3d


### PR DESCRIPTION
- Check the language.
- We might also want to add an explicit link to the specparam project as well, but that's maybe overkill for a warning message.