### PR TITLE
[MNT] - Fix order of reporting values in bw limits warning

### DIFF
--- a/fooof/core/strings.py
+++ b/fooof/core/strings.py
@@ -36,7 +36,7 @@ def gen_width_warning_str(freq_res, bwl):
     output = '\n'.join([
         '',
         'FOOOF WARNING: Lower-bound peak width limit is < or ~= the frequency resolution: ' + \
-            '{:1.2f} <= {:1.2f}'.format(freq_res, bwl),
+            '{:1.2f} <= {:1.2f}'.format(bwl, freq_res),
         '\tLower bounds below frequency-resolution have no effect ' + \
         '(effective lower bound is the frequency resolution).',
         '\tToo low a limit may lead to overfitting noise as small bandwidth peaks.',


### PR DESCRIPTION
It turns out in our bandwidth limits warning, the variables were flipped such that it printed out wrong. 

For example, with a frequency resolution of 1, and a bandwidth limit of 0.5, the current code would print:
`FOOOF WARNING: Lower-bound peak width limit is < or ~= the frequency resolution: 1.00 <= 0.50`

Which is unhelpfully wrong... 

This PR fixes this, by switching the variables to report properly. From my checks, I think it is just the warning that prints out wrong - the actual checks of the values seem correct.

This responds to this issue as reported in #244 