### PR TITLE
[MNT] - Add `check_freqs` to check for uneven frequency samples

### DIFF
--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -197,7 +197,10 @@ class FOOOF():
         ## RUN MODES
         # Set default debug mode - controls if an error is raised if model fitting is unsuccessful
         self._debug = False
-        # Set default check data mode - controls if an error is raised if NaN / Inf data are added
+        # Set default data checking modes - controls which checks get run on input data
+        #   check_freqs: check the frequency values, and raises an error for uneven spacing
+        self._check_freqs = True
+        #   check_data: checks the power values and raises an error for any NaN / Inf values
         self._check_data = True
 
         # Set internal settings, based on inputs, and initialize data & results attributes
@@ -1221,6 +1224,14 @@ class FOOOF():
         # Log power values
         power_spectrum = np.log10(power_spectrum)
 
+        ## Data checks - run checks on inputs based on check modes
+
+        if self._check_freqs:
+            # Check if the frequency data is unevenly spaced, and raise an error if so
+            freq_diffs = np.diff(freqs)
+            if not np.all(np.isclose(freq_diffs, freq_res)):
+                raise DataError("The input frequency values are not evenly spaced. "
+                                "The model expects equidistant frequency values in linear space.")
         if self._check_data:
             # Check if there are any infs / nans, and raise an error if so
             if np.any(np.isinf(power_spectrum)) or np.any(np.isnan(power_spectrum)):

--- a/fooof/tests/objs/test_fit.py
+++ b/fooof/tests/objs/test_fit.py
@@ -161,7 +161,11 @@ def test_fooof_checks():
     tfm.fit(xs, ys)
     assert tfm.freqs[0] != 0
 
-    # Check error if there is a post-logging inf or nan
+    # Check error for `check_freqs` - for if there is non-even frequency values
+    with raises(DataError):
+        tfm.fit(np.array([1, 2, 4]), np.array([1, 2, 3]))
+
+    # Check error for `check_data` - for if there is a post-logging inf or nan
     with raises(DataError):  # Double log (1) -> -inf
         tfm.fit(np.array([1, 2, 3]), np.log10(np.array([1, 2, 3])))
     with raises(DataError):  # Log (-1) -> NaN


### PR DESCRIPTION
This adds an explicit check when data added that the frequency vector is evenly spaced (equidistant points in linear space). The goal is to check and exclude situations in which there are gaps in frequencies (which could interact weirdly with things like the peak fitting). 

Note that this check can be turned off by setting the `_check_freqs` private attribute to False


Note: Related to #237, which brought up how unevenly spaced frequency values can lead to failures down the line.