### PR TITLE
[DOC] - Update README listing of other language support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,15 +130,40 @@ To install an editable version, download the development version as above, and r
 
     $ pip install -e .
 
-Matlab Support
---------------
+Other Language Support
+----------------------
 
-FOOOF is implemented in Python, but there is also Matlab wrapper that allows you to use FOOOF from Matlab.
-The wrapper is available in the `fooof_mat <http://github.com/fooof-tools/fooof_mat>`_ repository.
+The original implementation of FOOOF, available in this repository, is implemented in Python.
 
-If you would like to use FOOOF, from Python, within a pipeline that is mostly in Matlab, the
-`mat_py_mat <https://github.com/fooof-tools/mat_py_mat>`_
-repository also has some examples and utilities for doing so.
+If you wish to run FOOOF from another language, there are a couple potential options:
+- a `wrapper`, which allows for running the Python code from another language
+- a `reimplementation`, which reflects a new implementation of the fooof algorithm in another language
+
+Below are listed some examples of wrappers and/or reimplementations in other languages (non-exhaustive).
+
+Matlab
+~~~~~~
+
+In Matlab, there is a reimplementation available in common toolboxes:
+- The `Brainstorm <https://neuroimage.usc.edu/brainstorm/Introduction>`_ toolbox has a reimplementation of fooof
+    - See the Brainstorm `fooof tutorial <https://neuroimage.usc.edu/brainstorm/Tutorials/Fooof>`_
+- The `Fieldtrip <https://www.fieldtriptoolbox.org/>`_ also uses the same reimplementation
+    - See the Fieldtrip `fooof tutorial <https://www.fieldtriptoolbox.org/example/fooof/>`_
+
+There is also a Matlab wrapper in the `fooof_mat <http://github.com/fooof-tools/fooof_mat>`_ repository.
+
+Note that another option is to use Python FOOOF within a Matlab pipeline, as explored in the
+`mat_py_mat <https://github.com/fooof-tools/mat_py_mat>`_ repository.
+
+Other Languages
+~~~~~~~~~~~~~~~
+
+Other languages with wrappers include:
+- In Julia, there is
+`fooof wrapper <https://juliahub.com/ui/Packages/PyFOOOF/Ng8hN/0.1.0>`_
+- In R, fooof can be run using
+`reticulate <https://rstudio.github.io/reticulate/>`_, as
+`shown here <https://github.com/fooof-tools/DevelopmentalDemo/tree/main/R>`_
 
 Reference
 ---------


### PR DESCRIPTION
Nowadays, I think our recommendation if one is in Matlab is to use it through Fieldtrip or Brainstorm, right? Assuming so, this updates the README to note this, plus a bit more info on known ways to use specparam outside Python. 

Sidenote: since this is going in now to the 1.1 tag, it still says `fooof`, but this will be changed to `specparam` when merged to the name branch. 