### PR TITLE
[MNT] - Small fix up for null models

### DIFF
--- a/fooof/core/strings.py
+++ b/fooof/core/strings.py
@@ -356,9 +356,6 @@ def gen_results_fg_str(fg, concise=False):
     kns = fg.get_params('aperiodic_params', 'knee') \
         if fg.aperiodic_mode == 'knee' else np.array([0])
 
-    # Check if there are any power spectra that failed to fit
-    n_failed = sum(np.isnan(exps))
-
     str_lst = [
 
         # Header
@@ -369,7 +366,7 @@ def gen_results_fg_str(fg, concise=False):
 
         # Group information
         'Number of power spectra in the Group: {}'.format(len(fg.group_results)),
-        *[el for el in ['{} power spectra failed to fit'.format(n_failed)] if n_failed],
+        *[el for el in ['{} power spectra failed to fit'.format(fg.n_null_)] if fg.n_null_],
         '',
 
         # Frequency range and resolution

--- a/fooof/objs/group.py
+++ b/fooof/objs/group.py
@@ -68,10 +68,10 @@ class FOOOFGroup(FOOOF):
         Whether model results are available in the object.
     n_peaks_ : int
         The number of peaks fit in the model.
-    n_failed_fits_ : int
-        The number of models that failed to fit.
-    failed_fit_inds_ : list of int
-        The indices of any models that failed to fit.
+    n_null_ : int
+        The number of models that failed to fit and/or that are marked as null.
+    null_inds_ : list of int
+        The indices of any models that are null.
 
     Notes
     -----


### PR DESCRIPTION
Couple small fixes:
- in `FOOOFGroup`, update the docs to match that the attributes are called `n_null_` and `null_inds_`
- in report generation, use the `n_null_` attribute instead of counting missing exponents