### PR TITLE
[MNT] - Drop use of package_resources

### DIFF
--- a/fooof/tests/settings.py
+++ b/fooof/tests/settings.py
@@ -1,20 +1,14 @@
 """Settings for testing fooof."""
 
 import os
-
-# Use importlib to get package related paths, importing depending on Python version
-#   Note: can drop if/else when support goes to >= 3.9 (see: https://stackoverflow.com/a/75503824)
-import sys
-if sys.version_info >= (3, 9):
-    import importlib.resources as importlib_resources
-else:
-    import importlib_resources
+from pathlib import Path
 
 ###################################################################################################
 ###################################################################################################
 
 # Path Settings
-BASE_TEST_FILE_PATH = importlib_resources.files(__name__.split('.')[0]) / 'tests/test_files'
-TEST_DATA_PATH = os.path.join(BASE_TEST_FILE_PATH, 'data')
-TEST_REPORTS_PATH = os.path.join(BASE_TEST_FILE_PATH, 'reports')
-TEST_PLOTS_PATH = os.path.join(BASE_TEST_FILE_PATH, 'plots')
+TESTS_PATH = Path(os.path.abspath(os.path.dirname(__file__)))
+BASE_TEST_FILE_PATH = TESTS_PATH / 'test_files'
+TEST_DATA_PATH = BASE_TEST_FILE_PATH / 'data'
+TEST_REPORTS_PATH = BASE_TEST_FILE_PATH / 'reports'
+TEST_PLOTS_PATH = BASE_TEST_FILE_PATH / 'plots'

--- a/fooof/tests/settings.py
+++ b/fooof/tests/settings.py
@@ -1,13 +1,20 @@
 """Settings for testing fooof."""
 
 import os
-import pkg_resources as pkg
+
+# Use importlib to get package related paths, importing depending on Python version
+#   Note: can drop if/else when support goes to >= 3.9 (see: https://stackoverflow.com/a/75503824)
+import sys
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 ###################################################################################################
 ###################################################################################################
 
 # Path Settings
-BASE_TEST_FILE_PATH = pkg.resource_filename(__name__, 'test_files')
+BASE_TEST_FILE_PATH = importlib_resources.files(__name__.split('.')[0]) / 'tests/test_files'
 TEST_DATA_PATH = os.path.join(BASE_TEST_FILE_PATH, 'data')
 TEST_REPORTS_PATH = os.path.join(BASE_TEST_FILE_PATH, 'reports')
 TEST_PLOTS_PATH = os.path.join(BASE_TEST_FILE_PATH, 'plots')


### PR DESCRIPTION
The `pkg_resources` API, which comes with `setuptools` is being deprecated (see warning here: https://setuptools.pypa.io/en/latest/pkg_resources.html). Since we only use this to get the path for the test outputs (and moving to use `importlib` is a bit annoying across multiple python version - see here: https://stackoverflow.com/a/75503824), this update gets away with this entirely, and gets the needed path with just `os` and `pathlib`. 

In terms of review - key questions is whether it works properly / consistently across systems. It works for me locally and on Github Actions - so that seems promising. @ryanhammonds - can you check if this works for you on your system? If so, I think this should be okay to go with. 