### PR TITLE
[MNT] - Update build procedure

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE
+include LICENSE requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ summary:
 # Create a distribution build of the module
 dist:
 	@printf "\n\nCREATING DISTRIBUTION BUILD...\n"
-	@python setup.py sdist bdist_wheel
+	@python -m build
 	@printf "\n\nDISTRIBUTION BUILD CREATED\n\n\n"
 
 # Check a distribution build using twine

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@
 #   pytest              For running tests
 #   coverage            For running test coverage
 #   pylint              For running linting on code
-#   setuptools		For creating distributions
-#   build		For creating distributions
-#   twine		For checking and publishing distributions
+#   setuptools          For creating distributions
+#   build               For creating distributions
+#   twine               For checking and publishing distributions
 #
 # The following command line utilities are required:
 #   cloc                For counting lines of code

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@
 #   pytest              For running tests
 #   coverage            For running test coverage
 #   pylint              For running linting on code
-#   setuptools          For creating distributions
+#   setuptools		For creating distributions
+#   build		For creating distributions
 #   twine		For checking and publishing distributions
 #
 # The following command line utilities are required:
@@ -104,7 +105,7 @@ dist:
 # Check a distribution build using twine
 check-dist:
 	@printf "\n\nCHECKING DISTRIBUTION BUILD:\n"
-	twine check dist/*
+	@twine check dist/*
 	@printf "\n"
 
 # Clear out distribution files


### PR DESCRIPTION
Continuing the updates for things that are changing in the Python ecosystem - this updates away from calling `setup.py` directly in the build process, as this is now suggested against. 

New versions of `setuptools` print this out when running our current build command (`python setup.py sdist bdist_wheel`):
<img width="589" alt="Screen Shot 2023-07-08 at 10 26 46 AM" src="https://github.com/fooof-tools/fooof/assets/7727566/dbdf4c59-fc84-42a4-879a-e75a9a1f0a48">

Link: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
I didn't do the deep dive - but there is a useful table that indicates the new approach, using 
https://github.com/pypa/build

Related to which, this PR:
- updates the Makefile to use `build` to create the distribution
- adds the `requirements.txt` to the MANIFEST.in
    - it should probably have been in there (`build` needs it, as it builds the distribution in a venv)

Comparing the output distribution files, as far as I can tell they are the same from build as calling `setup.py`. 

Notably, as far as I understand, since we are using `setup.py` (and not `pyproject.toml`), I think `build` in this case uses `setuptools` and the `setup.py` file in the same way, so nothing really changes under the hood. This PR therefore just moves into the current best practice, and perhaps makes us a bit more ready if we do decide to update to `pyproject.toml` at some point (which I think is becoming the new standard). 

In terms of review - @ryanhammonds, when you get a chance could you double check that you can run the new `build` command and that it seems to work on your system?