### PR TITLE
Create setters/getters for check modes and fix management

### DIFF
--- a/fooof/core/info.py
+++ b/fooof/core/info.py
@@ -17,6 +17,7 @@ def get_description():
 
     - results : parameters for and measures of the model
     - settings : model settings
+    - run_modes: checks performed and errors raised
     - data : input data
     - meta_data : meta data of the inputs
     - arrays : data stored in arrays
@@ -29,6 +30,7 @@ def get_description():
                   'settings' : ['peak_width_limits', 'max_n_peaks',
                                 'min_peak_height', 'peak_threshold',
                                 'aperiodic_mode'],
+                  'run_modes': ['_debug', '_check_freqs', '_check_data'],
                   'data' : ['power_spectrum', 'freq_range', 'freq_res'],
                   'meta_data' : ['freq_range', 'freq_res'],
                   'arrays' : ['freqs', 'power_spectrum', 'aperiodic_params_',

--- a/fooof/data/data.py
+++ b/fooof/data/data.py
@@ -38,6 +38,25 @@ class FOOOFSettings(namedtuple('FOOOFSettings', ['peak_width_limits', 'max_n_pea
     __slots__ = ()
 
 
+class FOOOFRunModes(namedtuple('FOOOFRunModes', ['_debug', '_check_freqs',
+                                                 '_check_data'])):
+    """Checks performed and errors raised by the model.
+
+    Parameters
+    ----------
+    _debug :  bool
+       Whether to run in debug mode.
+    _check_freqs : bool
+        Whether to run in check freqs mode.
+    _check_data : bool
+        Whether to run in check data mode.
+    Notes
+    -----
+    This object is a data object, based on a NamedTuple, with immutable data attributes.
+    """
+    __slots__ = ()
+
+
 class FOOOFMetaData(namedtuple('FOOOFMetaData', ['freq_range', 'freq_res'])):
     """Metadata information about a power spectrum.
 

--- a/fooof/data/data.py
+++ b/fooof/data/data.py
@@ -38,25 +38,6 @@ class FOOOFSettings(namedtuple('FOOOFSettings', ['peak_width_limits', 'max_n_pea
     __slots__ = ()
 
 
-class FOOOFRunModes(namedtuple('FOOOFRunModes', ['_debug', '_check_freqs',
-                                                 '_check_data'])):
-    """Checks performed and errors raised by the model.
-
-    Parameters
-    ----------
-    _debug :  bool
-       Whether to run in debug mode.
-    _check_freqs : bool
-        Whether to run in check freqs mode.
-    _check_data : bool
-        Whether to run in check data mode.
-    Notes
-    -----
-    This object is a data object, based on a NamedTuple, with immutable data attributes.
-    """
-    __slots__ = ()
-
-
 class FOOOFMetaData(namedtuple('FOOOFMetaData', ['freq_range', 'freq_res'])):
     """Metadata information about a power spectrum.
 

--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -45,6 +45,8 @@ Run Modes
 _debug : bool
     Whether the object is set in debug mode.
     This should be controlled by using the `set_debug_mode` method.
+_check_freqs: bool
+    Whether to checked added added frequency values for even linear spacing.
 _check_data : bool
     Whether to check added data for NaN or Inf values, and fail out if present.
     This should be controlled by using the `set_check_data_mode` method.
@@ -199,7 +201,7 @@ class FOOOF():
         # Set default debug mode - controls if an error is raised if model fitting is unsuccessful
         self._debug = False
         # Set default data checking modes - controls which checks get run on input data
-        #   check_freqs: check the frequency values, and raises an error for uneven spacing
+        #   check_freqs: checks the frequency values, and raises an error for uneven spacing
         self._check_freqs = True
         #   check_data: checks the power values and raises an error for any NaN / Inf values
         self._check_data = True
@@ -568,6 +570,19 @@ class FOOOF():
                              for key in OBJ_DESC['settings']})
 
 
+    def get_run_modes(self):
+        """Return run modes of the current object.
+
+        Returns
+        -------
+        FOOOFRunModes
+            Object containing the run_modes from the current object.
+        """
+
+        return FOOOFRunModes(**{key : getattr(self, key) \
+                             for key in OBJ_DESC['run_modes']})
+
+
     def get_meta_data(self):
         """Return data information from the current object.
 
@@ -723,6 +738,18 @@ class FOOOF():
         self._debug = debug
 
 
+    def set_check_freqs_mode(self, check_freqs):
+        """Set check freqs mode, which controls if an error is raised for unevenly spaced input frequencies.
+
+        Parameters
+        ----------
+        check_freqs : bool
+            Whether to run in check freqs mode.
+        """
+
+        self._check_freqs = check_freqs
+
+
     def set_check_data_mode(self, check_data):
         """Set check data mode, which controls if an error is raised if NaN or Inf data are added.
 
@@ -732,6 +759,23 @@ class FOOOF():
             Whether to run in check data mode.
         """
 
+        self._check_data = check_data
+
+
+    def set_run_modes(self, debug, check_freqs, check_data):
+        """Simultaneously set all run modes.
+
+        Parameters
+        ----------
+        debug : bool
+            Whether to run in debug mode.
+        check_freqs : bool
+            Whether to run in check freqs mode.
+        check_data : bool
+            Whether to run in check data mode.
+        """
+        self._debug = debug
+        self._check_freqs = check_freqs
         self._check_data = check_data
 
 

--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -575,12 +575,12 @@ class FOOOF():
 
         Returns
         -------
-        FOOOFRunModes
-            Object containing the run_modes from the current object.
+        data: dict
+            Dictionary containing the run_modes from the current object.
         """
 
-        return FOOOFRunModes(**{key : getattr(self, key) \
-                             for key in OBJ_DESC['run_modes']})
+        return {key : getattr(self, key) \
+                    for key in OBJ_DESC['run_modes']}
 
 
     def get_meta_data(self):

--- a/fooof/objs/group.py
+++ b/fooof/objs/group.py
@@ -456,9 +456,9 @@ class FOOOFGroup(FOOOF):
             The FOOOFResults data loaded into a FOOOF object.
         """
 
-        # Initialize a FOOOF object, with same settings & check data mode as current FOOOFGroup
+        # Initialize a FOOOF object, with same settings & run modes as current FOOOFGroup
         fm = FOOOF(*self.get_settings(), verbose=self.verbose)
-        fm.set_check_data_mode(self._check_data)
+        fm.set_run_modes(*self.get_run_modes())
 
         # Add data for specified single power spectrum, if available
         #   The power spectrum is inverted back to linear, as it is re-logged when added to FOOOF
@@ -494,8 +494,9 @@ class FOOOFGroup(FOOOF):
         # Check and convert indices encoding to list of int
         inds = check_inds(inds)
 
-        # Initialize a new FOOOFGroup object, with same settings as current FOOOFGroup
+        # Initialize a new FOOOFGroup object, with same settings and run modes as current FOOOFGroup
         fg = FOOOFGroup(*self.get_settings(), verbose=self.verbose)
+        fg.set_run_modes(*self.get_run_modes())
 
         # Add data for specified power spectra, if available
         #   The power spectra are inverted back to linear, as they are re-logged when added to FOOOF

--- a/fooof/objs/group.py
+++ b/fooof/objs/group.py
@@ -458,7 +458,7 @@ class FOOOFGroup(FOOOF):
 
         # Initialize a FOOOF object, with same settings & run modes as current FOOOFGroup
         fm = FOOOF(*self.get_settings(), verbose=self.verbose)
-        fm.set_run_modes(*self.get_run_modes())
+        fm.set_run_modes(*self.get_run_modes().values())
 
         # Add data for specified single power spectrum, if available
         #   The power spectrum is inverted back to linear, as it is re-logged when added to FOOOF
@@ -496,7 +496,7 @@ class FOOOFGroup(FOOOF):
 
         # Initialize a new FOOOFGroup object, with same settings and run modes as current FOOOFGroup
         fg = FOOOFGroup(*self.get_settings(), verbose=self.verbose)
-        fg.set_run_modes(*self.get_run_modes())
+        fg.set_run_modes(*self.get_run_modes().values())
 
         # Add data for specified power spectra, if available
         #   The power spectra are inverted back to linear, as they are re-logged when added to FOOOF


### PR DESCRIPTION
This fix adds setters and getters for run_modes in fooof objects in fit.py. The dictionary returned by get_description() in info.py includes attributes for all run_modes. The get_fooof() and get_group() functions in group.py are now updated to probably transfer run mode settings from the current object to newly instantiated objects. Documentation relating to run_modes was updated in all files.

This Pull Request relates to this [issue](https://github.com/fooof-tools/fooof/issues/292).