### PR TITLE
[MNT] - Optimizations for curve fit

### DIFF
--- a/fooof/core/funcs.py
+++ b/fooof/core/funcs.py
@@ -58,11 +58,8 @@ def expo_function(xs, *params):
         Output values for exponential function.
     """
 
-    ys = np.zeros_like(xs)
-
     offset, knee, exp = params
-
-    ys = ys + offset - np.log10(knee + xs**exp)
+    ys = offset - np.log10(knee + xs**exp)
 
     return ys
 
@@ -86,11 +83,8 @@ def expo_nk_function(xs, *params):
         Output values for exponential function, without a knee.
     """
 
-    ys = np.zeros_like(xs)
-
     offset, exp = params
-
-    ys = ys + offset - np.log10(xs**exp)
+    ys = offset - np.log10(xs**exp)
 
     return ys
 
@@ -111,11 +105,8 @@ def linear_function(xs, *params):
         Output values for linear function.
     """
 
-    ys = np.zeros_like(xs)
-
     offset, slope = params
-
-    ys = ys + offset + (xs*slope)
+    ys = offset + (xs*slope)
 
     return ys
 
@@ -136,11 +127,8 @@ def quadratic_function(xs, *params):
         Output values for quadratic function.
     """
 
-    ys = np.zeros_like(xs)
-
     offset, slope, curve = params
-
-    ys = ys + offset + (xs*slope) + ((xs**2)*curve)
+    ys = offset + (xs*slope) + ((xs**2)*curve)
 
     return ys
 

--- a/fooof/core/funcs.py
+++ b/fooof/core/funcs.py
@@ -32,9 +32,7 @@ def gaussian_function(xs, *params):
 
     ys = np.zeros_like(xs)
 
-    for ii in range(0, len(params), 3):
-
-        ctr, hgt, wid = params[ii:ii+3]
+    for ctr, hgt, wid in zip(*[iter(params)] * 3):
 
         ys = ys + hgt * np.exp(-(xs-ctr)**2 / (2*wid**2))
 

--- a/fooof/core/jacobians.py
+++ b/fooof/core/jacobians.py
@@ -12,7 +12,7 @@ import numpy as np
 ###################################################################################################
 ###################################################################################################
 
-## Periodic fit functions
+## Periodic Jacobian functions
 
 def jacobian_gauss(xs, *params):
     """Create the Jacobian matrix for the Gaussian function.
@@ -51,7 +51,7 @@ def jacobian_gauss(xs, *params):
     return jacobian
 
 
-## Aperiodic fit functions
+## Aperiodic Jacobian functions
 
 def jacobian_expo(xs, *params):
     """Create the Jacobian matrix for the exponential function.

--- a/fooof/core/jacobians.py
+++ b/fooof/core/jacobians.py
@@ -30,19 +30,25 @@ def jacobian_gauss(xs, *params):
         Jacobian matrix, with shape [len(xs), n_params].
     """
 
-    jacobians = []
-    for a, b, c in zip(*[iter(params)] * 3):
+    jacobians = np.zeros((len(xs), len(params)))
 
-        sub = b * np.exp((-(((-a + xs)**2) / (2 * c**2))))
+    for i, (a, b, c) in enumerate(zip(*[iter(params)] * 3)):
 
-        jacobian = np.hstack([
-            (sub * (-a + xs) / c**2).reshape(-1, 1),
-            np.exp(-(-a + xs)**2 / (2 * c**2)).reshape(-1, 1),
-            (sub * (-a + xs)**2 / c**3).reshape(-1, 1),
-        ])
-        jacobians.append(jacobian)
+        ax = -a + xs
+        ax2 = ax**2
 
-    return np.hstack(jacobians)
+        c2 = c**2
+        c3 = c**3
+
+        exp = np.exp(-ax2 / (2 * c2))
+        exp_b = exp * b
+
+        ii = i * 3
+        jacobians[:, ii] = (exp_b * ax) / c2
+        jacobians[:, ii+1] = exp
+        jacobians[:, ii+2] = (exp_b * ax2) / c3
+
+    return jacobians
 
 
 ## Aperiodic fit functions

--- a/fooof/core/jacobians.py
+++ b/fooof/core/jacobians.py
@@ -1,0 +1,51 @@
+""""Functions for computing Jacobian matrices to be used during fitting."""
+
+import numpy as np
+
+###################################################################################################
+###################################################################################################
+
+## Periodic fit functions
+
+def jacobian_gauss(xs, *params):
+    """Create the Jacobian matrix for the Guassian function."""
+
+    jacobians = []
+    for a, b, c in zip(*[iter(params)] * 3):
+
+        sub = b * np.exp((-(((-a + xs)**2) / (2 * c**2))))
+
+        jacobian = np.hstack([
+            (sub * (-a + xs) / c**2).reshape(-1, 1),
+            np.exp(-(-a + xs)**2 / (2 * c**2)).reshape(-1, 1),
+            (sub * (-a + xs)**2 / c**3).reshape(-1, 1),
+        ])
+        jacobians.append(jacobian)
+
+    return np.hstack(jacobians)
+
+
+## Aperiodic fit functions
+
+def jacobian_expo(xs, *params):
+    """Create the Jacobian matrix for the exponential function."""
+
+    a, b, c = params
+    jacobian = np.hstack([
+        np.ones([len(xs), 1]),
+        - (1 / (b + xs**c)).reshape(-1, 1),
+        -((xs**c * np.log10(xs)) / (b + xs**c)).reshape(-1, 1),
+    ])
+
+    return jacobian
+
+
+def jacobian_expo_nk(xs, *params):
+    """Create the Jacobian matrix for the exponential no-knee function."""
+
+    jacobian = np.hstack([
+        np.ones([len(xs), 1]),
+        (-np.log10(xs) / np.log10(10)).reshape(-1, 1),
+    ])
+
+    return jacobian

--- a/fooof/core/jacobians.py
+++ b/fooof/core/jacobians.py
@@ -1,4 +1,11 @@
-""""Functions for computing Jacobian matrices to be used during fitting."""
+""""Functions for computing Jacobian matrices to be used during fitting.
+
+Notes
+-----
+These functions line up with those in `funcs`.
+The parameters in these functions are labelled {a, b, c, ...}, but follow the order in `funcs`.
+These functions are designed to be passed into `curve_fit` to provide a computed Jacobian.
+"""
 
 import numpy as np
 
@@ -8,7 +15,20 @@ import numpy as np
 ## Periodic fit functions
 
 def jacobian_gauss(xs, *params):
-    """Create the Jacobian matrix for the Guassian function."""
+    """Create the Jacobian matrix for the Guassian function.
+
+    Parameters
+    ----------
+    xs : 1d array
+        Input x-axis values.
+    *params : float
+        Parameters for the function.
+
+    Returns
+    -------
+    jacobian : 2d array
+        Jacobian matrix, with shape [len(xs), n_params].
+    """
 
     jacobians = []
     for a, b, c in zip(*[iter(params)] * 3):
@@ -28,7 +48,20 @@ def jacobian_gauss(xs, *params):
 ## Aperiodic fit functions
 
 def jacobian_expo(xs, *params):
-    """Create the Jacobian matrix for the exponential function."""
+    """Create the Jacobian matrix for the exponential function.
+
+    Parameters
+    ----------
+    xs : 1d array
+        Input x-axis values.
+    *params : float
+        Parameters for the function.
+
+    Returns
+    -------
+    jacobian : 2d array
+        Jacobian matrix, with shape [len(xs), n_params].
+    """
 
     a, b, c = params
     jacobian = np.hstack([
@@ -41,7 +74,20 @@ def jacobian_expo(xs, *params):
 
 
 def jacobian_expo_nk(xs, *params):
-    """Create the Jacobian matrix for the exponential no-knee function."""
+    """Create the Jacobian matrix for the exponential no-knee function.
+
+    Parameters
+    ----------
+    xs : 1d array
+        Input x-axis values.
+    *params : float
+        Parameters for the function.
+
+    Returns
+    -------
+    jacobian : 2d array
+        Jacobian matrix, with shape [len(xs), n_params].
+    """
 
     jacobian = np.hstack([
         np.ones([len(xs), 1]),

--- a/fooof/core/jacobians.py
+++ b/fooof/core/jacobians.py
@@ -3,7 +3,7 @@
 Notes
 -----
 These functions line up with those in `funcs`.
-The parameters in these functions are labelled {a, b, c, ...}, but follow the order in `funcs`.
+The parameters in these functions are labeled {a, b, c, ...}, but follow the order in `funcs`.
 These functions are designed to be passed into `curve_fit` to provide a computed Jacobian.
 """
 
@@ -15,7 +15,7 @@ import numpy as np
 ## Periodic fit functions
 
 def jacobian_gauss(xs, *params):
-    """Create the Jacobian matrix for the Guassian function.
+    """Create the Jacobian matrix for the Gaussian function.
 
     Parameters
     ----------
@@ -30,7 +30,7 @@ def jacobian_gauss(xs, *params):
         Jacobian matrix, with shape [len(xs), n_params].
     """
 
-    jacobians = np.zeros((len(xs), len(params)))
+    jacobian = np.zeros((len(xs), len(params)))
 
     for i, (a, b, c) in enumerate(zip(*[iter(params)] * 3)):
 
@@ -44,11 +44,11 @@ def jacobian_gauss(xs, *params):
         exp_b = exp * b
 
         ii = i * 3
-        jacobians[:, ii] = (exp_b * ax) / c2
-        jacobians[:, ii+1] = exp
-        jacobians[:, ii+2] = (exp_b * ax2) / c3
+        jacobian[:, ii] = (exp_b * ax) / c2
+        jacobian[:, ii+1] = exp
+        jacobian[:, ii+2] = (exp_b * ax2) / c3
 
-    return jacobians
+    return jacobian
 
 
 ## Aperiodic fit functions

--- a/fooof/core/jacobians.py
+++ b/fooof/core/jacobians.py
@@ -70,11 +70,13 @@ def jacobian_expo(xs, *params):
     """
 
     a, b, c = params
-    jacobian = np.hstack([
-        np.ones([len(xs), 1]),
-        - (1 / (b + xs**c)).reshape(-1, 1),
-        -((xs**c * np.log10(xs)) / (b + xs**c)).reshape(-1, 1),
-    ])
+
+    xs_c = xs**c
+    b_xs_c = xs_c + b
+
+    jacobian = np.ones((len(xs), len(params)))
+    jacobian[:, 1] = -1 / b_xs_c
+    jacobian[:, 2] = -(xs_c * np.log10(xs)) / b_xs_c
 
     return jacobian
 
@@ -95,9 +97,7 @@ def jacobian_expo_nk(xs, *params):
         Jacobian matrix, with shape [len(xs), n_params].
     """
 
-    jacobian = np.hstack([
-        np.ones([len(xs), 1]),
-        (-np.log10(xs) / np.log10(10)).reshape(-1, 1),
-    ])
+    jacobian = np.ones((len(xs), len(params)))
+    jacobian[:, 1] = -np.log10(xs)
 
     return jacobian

--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -201,6 +201,7 @@ class FOOOF():
         # The maximum number of calls to the curve fitting function
         self._maxfev = 5000
         # The tolerance setting for curve fitting (see scipy.curve_fit - ftol / xtol / gtol)
+        #   Here reduce tolerance to speed fitting. Set value to 1e-8 to match curve_fit default
         self._tol = 0.00001
 
         ## RUN MODES

--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -946,7 +946,8 @@ class FOOOF():
                 warnings.simplefilter("ignore")
                 aperiodic_params, _ = curve_fit(get_ap_func(self.aperiodic_mode),
                                                 freqs, power_spectrum, p0=guess,
-                                                maxfev=self._maxfev, bounds=ap_bounds)
+                                                maxfev=self._maxfev, bounds=ap_bounds,
+                                                check_finite=False)
         except RuntimeError as excp:
             error_msg = ("Model fitting failed due to not finding parameters in "
                          "the simple aperiodic component fit.")
@@ -1003,7 +1004,8 @@ class FOOOF():
                 warnings.simplefilter("ignore")
                 aperiodic_params, _ = curve_fit(get_ap_func(self.aperiodic_mode),
                                                 freqs_ignore, spectrum_ignore, p0=popt,
-                                                maxfev=self._maxfev, bounds=ap_bounds)
+                                                maxfev=self._maxfev, bounds=ap_bounds,
+                                                check_finite=False)
         except RuntimeError as excp:
             error_msg = ("Model fitting failed due to not finding "
                          "parameters in the robust aperiodic fit.")
@@ -1149,7 +1151,8 @@ class FOOOF():
         # Fit the peaks
         try:
             gaussian_params, _ = curve_fit(gaussian_function, self.freqs, self._spectrum_flat,
-                                           p0=guess, maxfev=self._maxfev, bounds=gaus_param_bounds)
+                                           p0=guess, maxfev=self._maxfev, bounds=gaus_param_bounds,
+                                           check_finite=False)
         except RuntimeError as excp:
             error_msg = ("Model fitting failed due to not finding "
                          "parameters in the peak component fit.")

--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -71,6 +71,7 @@ from fooof.core.reports import save_report_fm
 from fooof.core.modutils import copy_doc_func_to_method
 from fooof.core.utils import group_three, check_array_dim
 from fooof.core.funcs import gaussian_function, get_ap_func, infer_ap_func
+from fooof.core.jacobians import jacobian_gauss
 from fooof.core.errors import (FitError, NoModelError, DataError,
                                NoDataError, InconsistentDataError)
 from fooof.core.strings import (gen_settings_str, gen_results_fm_str,
@@ -1159,7 +1160,7 @@ class FOOOF():
             gaussian_params, _ = curve_fit(gaussian_function, self.freqs, self._spectrum_flat,
                                            p0=guess, maxfev=self._maxfev, bounds=gaus_param_bounds,
                                            ftol=self._tol, xtol=self._tol, gtol=self._tol,
-                                           check_finite=False)
+                                           check_finite=False, jac=jacobian_gauss)
         except RuntimeError as excp:
             error_msg = ("Model fitting failed due to not finding "
                          "parameters in the peak component fit.")

--- a/fooof/objs/fit.py
+++ b/fooof/objs/fit.py
@@ -192,11 +192,15 @@ class FOOOF():
         self._gauss_overlap_thresh = 0.75
         # Parameter bounds for center frequency when fitting gaussians, in terms of +/- std dev
         self._cf_bound = 1.5
-        # The maximum number of calls to the curve fitting function
-        self._maxfev = 5000
         # The error metric to calculate, post model fitting. See `_calc_error` for options
         #   Note: this is for checking error post fitting, not an objective function for fitting
         self._error_metric = 'MAE'
+
+        ## PRIVATE CURVE_FIT SETTINGS
+        # The maximum number of calls to the curve fitting function
+        self._maxfev = 5000
+        # The tolerance setting for curve fitting (see scipy.curve_fit - ftol / xtol / gtol)
+        self._tol = 0.00001
 
         ## RUN MODES
         # Set default debug mode - controls if an error is raised if model fitting is unsuccessful
@@ -947,6 +951,7 @@ class FOOOF():
                 aperiodic_params, _ = curve_fit(get_ap_func(self.aperiodic_mode),
                                                 freqs, power_spectrum, p0=guess,
                                                 maxfev=self._maxfev, bounds=ap_bounds,
+                                                ftol=self._tol, xtol=self._tol, gtol=self._tol,
                                                 check_finite=False)
         except RuntimeError as excp:
             error_msg = ("Model fitting failed due to not finding parameters in "
@@ -1005,6 +1010,7 @@ class FOOOF():
                 aperiodic_params, _ = curve_fit(get_ap_func(self.aperiodic_mode),
                                                 freqs_ignore, spectrum_ignore, p0=popt,
                                                 maxfev=self._maxfev, bounds=ap_bounds,
+                                                ftol=self._tol, xtol=self._tol, gtol=self._tol,
                                                 check_finite=False)
         except RuntimeError as excp:
             error_msg = ("Model fitting failed due to not finding "
@@ -1152,6 +1158,7 @@ class FOOOF():
         try:
             gaussian_params, _ = curve_fit(gaussian_function, self.freqs, self._spectrum_flat,
                                            p0=guess, maxfev=self._maxfev, bounds=gaus_param_bounds,
+                                           ftol=self._tol, xtol=self._tol, gtol=self._tol,
                                            check_finite=False)
         except RuntimeError as excp:
             error_msg = ("Model fitting failed due to not finding "

--- a/fooof/tests/core/test_jacobians.py
+++ b/fooof/tests/core/test_jacobians.py
@@ -1,6 +1,5 @@
 """Tests for fooof.core.jacobians."""
 
-
 from fooof.core.jacobians import *
 
 ###################################################################################################

--- a/fooof/tests/core/test_jacobians.py
+++ b/fooof/tests/core/test_jacobians.py
@@ -1,0 +1,34 @@
+"""Tests for fooof.core.jacobians."""
+
+
+from fooof.core.jacobians import *
+
+###################################################################################################
+###################################################################################################
+
+def test_jacobian_gauss():
+
+    xs = np.arange(1, 100)
+    ctr, hgt, wid = 50, 5, 10
+
+    jacobian = jacobian_gauss(xs, ctr, hgt, wid)
+    assert isinstance(jacobian, np.ndarray)
+    assert jacobian.shape == (len(xs), 3)
+
+def test_jacobian_expo():
+
+    xs = np.arange(1, 100)
+    off, knee, exp = 10, 5, 2
+
+    jacobian = jacobian_expo(xs, off, knee, exp)
+    assert isinstance(jacobian, np.ndarray)
+    assert jacobian.shape == (len(xs), 3)
+
+def test_jacobian_expo_nk():
+
+    xs = np.arange(1, 100)
+    off, exp = 10, 2
+
+    jacobian = jacobian_expo_nk(xs, off, exp)
+    assert isinstance(jacobian, np.ndarray)
+    assert jacobian.shape == (len(xs), 2)

--- a/fooof/tests/objs/test_fit.py
+++ b/fooof/tests/objs/test_fit.py
@@ -391,7 +391,7 @@ def test_fooof_fit_failure():
 
     ## Induce a runtime error, and check it runs through
     tfm = FOOOF(verbose=False)
-    tfm._maxfev = 5
+    tfm._maxfev = 2
 
     tfm.fit(*gen_power_spectrum([3, 50], [50, 2], [10, 0.5, 2, 20, 0.3, 4]))
 
@@ -417,7 +417,7 @@ def test_fooof_debug():
     """Test FOOOF in debug mode, including with fit failures."""
 
     tfm = FOOOF(verbose=False)
-    tfm._maxfev = 5
+    tfm._maxfev = 2
 
     tfm.set_debug_mode(True)
     assert tfm._debug is True


### PR DESCRIPTION
This is a series of small tweaks to the fit algorithm that should result in minor improvements in run speed. 

Updates include:
- a slightly more efficient stepping across params in gaussian function
- removing unneeding 'ys' initialization in aperiodic fit functions
- setting `check_finite` to False in curve_fit (since we do our own data checking)
- expose `curve_fit` tolerance settings as a private setting, and set new default value that is a bit more liberal
- provide precomputed Jacobian matrix, for the Guassian curve_fit call*

*I did add the Jacobians for the AP functions as well, but there was more mixed results whether this provided any speedup - notably these calls are already pretty fast, and so based on [this](https://stackoverflow.com/questions/24391242/scipys-curve-fit-leastsq-become-slower-when-given-the-jacobian) post, I think for AP funcs we are often in a case in which the checks on the passed in Jacobian supercede any benefit as compared to computing it. Because of this, I did not actually set the Jacobian functions to be used in the aperiodic component curve_fit calls. 

## Results !?

Without being particularly rigorous about profiling, pretty quick / simple tests suggest this update provides something in the range of at least 5-20% speed up even in the simplest fitting cases (which is what I was expecting), but it has an unexpectedly outsized effects on more complex cases - and so in cases with knees and/or more peaks, noise etc - I'm seeing what looks like 2-3X speed increases! I didn't profile in too much detail exactly where this comes from, but I _think_ a bit part is that when we start having multiple Gaussians estimating the Jacobian is slow, but it's actually quick and easy to pass in, and also the tolerance shift can have a notable impact (the other changes are less impactful). 

In terms of outputs everything other than the tolerance levels change should have zero effect (meaning should get numerically _exactly_ the same results out). The tolerance change _can_ (though does not necessarily) change results - I've only seen it change beyond what should be notable resolution (eg. changing a peak bandwidth value by ~0.005 or so). If it's indeed limited to the this magnitude of impact, I think it's fine / worth the trade off. Note that the actual value I set (0.00001, replacing the otherwise default of 1e-8) is arbitrary - the higher this gets, more speed increase, but more chance of having more notably impacts. Also, this was added as a private setting, so one can also set it back to match previous default (`fm._tol = 1e-8`) to return to exactly the same as 1.0, or set a different value as needed. 

## Notes

- I followed some pointers from [this](https://stackoverflow.com/questions/31070618/how-to-speed-up-python-curve-fit-over-a-2d-array) stack overflow post to try and optimize things.
- The formulas for the Jacobian matrix calculations all come from [Wolfram Alpha](https://www.wolframalpha.com/). As far as I can see they provide numerically exact answers to not passing in the jacobian and it being estimated, so the outputs are exactly the same.

## Reviewing

There's not too much changed in the code to check - what would be good is if someone (@ryanhammonds perhaps) could do a quick check to replicate that a) this branch is at least a bit quicker than main, and b) you see no real change in output parameters. I'm also tagging @rdgao because you might be interested in these changes, and/or have some more knowledgeable insight over and above my heuristic updates here. 

## Addendum: what I learned about `curve_fit`

Doing some quick profiling, we spend basically all of our time in `curve_fit`, meaning it's the only real target for meaningful optimization, and within that, we spend the vast majority of our time doing the Gaussian fit (not really the guess procedure, but the curve_fit call itself). Why here? Well, it turns out with no bounds, `curve_fit` estimation method ends up as the Levenberg-Marquardt algorithm which is very fast - but does not support bounds. For peaks, we need bounds - adding those pushes the method to default to the Trust Region Reflective ('trf') which is _way_ slower. Notably, there is another option for bounded estimations ('dogbox') - which is sometimes a bit faster, but not consistently enough to try and change it (both methods give the exact same results as far as I can see).

Implications of this:
- adding bounds, in general, slows things down _a lot_. We can't avoid this for peaks. In general, we do not provide bounds for AP, and this is (somewhat counter-intuitively) much quicker than if we did, which is useful to know.
- we spend almost all our fitting time within the `curve_fit` function, with no other meaningful targets for optimization. This PR does what I could figure out to optimize how we call `curve_fit` - but my sense beyond this is that we are hitting a limit of what we can speed up without looking for different / faster implementations of the fitting procedure itself (in particular with bounds).