### PR TITLE
[BUG] - Fix description of time constant estimation

### DIFF
--- a/fooof/tests/utils/test_params.py
+++ b/fooof/tests/utils/test_params.py
@@ -13,7 +13,7 @@ def test_compute_knee_frequency():
 
 def test_compute_time_constant():
 
-    assert compute_time_constant(100)
+    assert compute_time_constant(10)
 
 def test_compute_fwhm():
 

--- a/fooof/utils/params.py
+++ b/fooof/utils/params.py
@@ -19,9 +19,27 @@ def compute_knee_frequency(knee, exponent):
     -------
     float
         Frequency value, in Hz, of the knee occurs.
+
+    Notes
+    -----
+    The knee frequency is an estimate of the frequency in spectrum at which the spectrum
+    moves from the plateau region to the exponential decay.
+
+    This approach for estimating the knee frequency comes from [1]_ (see [2]_ for code).
+
+    Note that this provides an estimate of the knee frequency, but is not, in the general case,
+    a precisely defined value. In particular, this conversion is based on the case of a Lorentzian
+    with exponent = 2, and for other exponent values provides a non-exact approximation.
+
+    References
+    ----------
+    .. [1] Gao, R., van den Brink, R. L., Pfeffer, T., & Voytek, B. (2020). Neuronal timescales
+           are functionally dynamic and shaped by cortical microarchitecture. Elife, 9, e61277.
+           https://doi.org/10.7554/eLife.61277
+    .. [2] https://github.com/rdgao/field-echos/blob/master/echo_utils.py#L64
     """
 
-    return knee ** (1./exponent)
+    return knee ** (1. / exponent)
 
 
 def compute_time_constant(knee_freq):
@@ -36,9 +54,20 @@ def compute_time_constant(knee_freq):
     -------
     float
         Calculated time constant value, tau, given the knee frequency.
+
+    Notes
+    -----
+    This approach for estimating the time constant comes from [1]_ (see [2]_ for code).
+
+    References
+    ----------
+    .. [1] Gao, R., van den Brink, R. L., Pfeffer, T., & Voytek, B. (2020). Neuronal timescales
+           are functionally dynamic and shaped by cortical microarchitecture. Elife, 9, e61277.
+           https://doi.org/10.7554/eLife.61277
+    .. [2] https://github.com/rdgao/field-echos/blob/master/echo_utils.py#L65
     """
 
-    return 1. / (2*np.pi*knee_freq)
+    return 1. / (2 * np.pi * knee_freq)
 
 
 def compute_fwhm(std):

--- a/fooof/utils/params.py
+++ b/fooof/utils/params.py
@@ -24,21 +24,21 @@ def compute_knee_frequency(knee, exponent):
     return knee ** (1./exponent)
 
 
-def compute_time_constant(knee):
-    """Compute the characteristic time constant based on the knee value.
+def compute_time_constant(knee_freq):
+    """Compute the characteristic time constant from the estimated knee frequency.
 
     Parameters
     ----------
-    knee : float
-        Knee parameter value.
+    knee_freq : float
+        Estimated knee frequency.
 
     Returns
     -------
     float
-        Calculated time constant value, tau, given the knee parameter.
+        Calculated time constant value, tau, given the knee frequency.
     """
 
-    return 1. / (2*np.pi*knee)
+    return 1. / (2*np.pi*knee_freq)
 
 
 def compute_fwhm(std):


### PR DESCRIPTION
We have a function the repo to estimate 'timescales', added in here. I happened to notice that the function we have here described the calculation as being estimated from the knee _parameter_, whereas Richard's work estimates it from the knee _frequency_ - which I assume is correct? If so, this is currently incorrectly described here, and this PR updates that.

This is what I'm following from Richard's work: 
https://github.com/rdgao/field-echos/blob/master/echo_utils.py#L65

I know the "knee frequency" calculation is an estimation - this function should at least be updated to describe the correct parameter - should we also add a bit of note describing it more and/or referencing this to Richards paper? Thoughts, @rdgao?