### PR TITLE
[MNT] - Update deprecation warning

### DIFF
--- a/fooof/__init__.py
+++ b/fooof/__init__.py
@@ -4,8 +4,7 @@ from .version import __version__
 
 # Deprecation of fooof / move to specparam message
 #   Note: this warning is for fooof v1.1 specifically, and should be removed in specparam 2.0
-from warnings import warn, simplefilter
-#simplefilter('always')  # make sure user sees it once, on every import
+from warnings import warn
 DEPRECATION_TEXT = ("\nThe `fooof` package is being deprecated and replaced by the "
     "`specparam` (spectral parameterization) package."
     "\nThis version of `fooof` (1.1) is fully functional, but will not be further updated."

--- a/fooof/__init__.py
+++ b/fooof/__init__.py
@@ -5,7 +5,7 @@ from .version import __version__
 # Deprecation of fooof / move to specparam message
 #   Note: this warning is for fooof v1.1 specifically, and should be removed in specparam 2.0
 from warnings import warn, simplefilter
-simplefilter('always')  # make sure user sees it once, on every import
+#simplefilter('always')  # make sure user sees it once, on every import
 DEPRECATION_TEXT = ("\nThe `fooof` package is being deprecated and replaced by the "
     "`specparam` (spectral parameterization) package."
     "\nThis version of `fooof` (1.1) is fully functional, but will not be further updated."

--- a/fooof/version.py
+++ b/fooof/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.1.0rc2'
+__version__ = '1.1.0rc3'


### PR DESCRIPTION
We previously set the deprecation warning to an "always" filter, however this has unintended consequences - it voids user's own filters, so it makes the warning impossible to turn off. If running code in parallel, this can lead to it being practically impossible to stop the warning being printed multiple times, making it _very_ annoying. I think we shouldn't be over-riding users own warnings settings - so this removes the "always" filter. 

Also - bump version to rc3!