### PR TITLE
Reorder exponent and offset columns

### DIFF
--- a/specparam/core/info.py
+++ b/specparam/core/info.py
@@ -78,7 +78,7 @@ def get_ap_indices(aperiodic_mode):
     if aperiodic_mode == 'fixed':
         labels = ('offset', 'exponent')
     elif aperiodic_mode == 'knee':
-        labels = ('offset', 'knee', 'exponent')
+        labels = ('offset', 'exponent', 'knee')
     else:
         raise ValueError("Aperiodic mode not understood.")
 


### PR DESCRIPTION
First of all, thank you for this wonderful package.

In this revision, the exponent will always be the second column of the aperiodic parameters. I spent a couple of hours figuring out why changing the aperiodic mode from 'fixed' to 'knee' dramatically altered the results. Eventually, I discovered that switching these parameters changes the index of the exponent, which is then replaced by the knee parameters.