### PR TITLE
[MNT] - try new ubuntu tagged test version for py37

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     # Tag ubuntu version to 22.04, in order to support python 3.7
     #   See issue: https://github.com/actions/runner-images/issues/10893
     #   When ready to drop 3.7, can update from 'ubuntu-22.04' -> 'ubuntu-latest'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     env:
       MODULE_NAME: specparam
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    # Tag ubuntu version to 24.04, in order to support python 3.7
+    #   See issue: https://github.com/actions/runner-images/issues/10893
+    #   When ready to drop 3.7, can update from 'ubuntu-24.04' -> 'ubuntu-latest'
+    runs-on: ubuntu-24.04
     env:
       MODULE_NAME: specparam
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   build:
 
-    # Tag ubuntu version to 24.04, in order to support python 3.7
+    # Tag ubuntu version to 22.04, in order to support python 3.7
     #   See issue: https://github.com/actions/runner-images/issues/10893
-    #   When ready to drop 3.7, can update from 'ubuntu-24.04' -> 'ubuntu-latest'
+    #   When ready to drop 3.7, can update from 'ubuntu-22.04' -> 'ubuntu-latest'
     runs-on: ubuntu-24.04
     env:
       MODULE_NAME: specparam


### PR DESCRIPTION
So this keeps the lights on for now for testing Python 3.7, though I think it might stop working again soon, so we might need to make some decisions on what Python versions we officially support / test against. 