### PR TITLE
Fix a bug for getting all peaks in get_band_peak_group()'s documetation

### DIFF
--- a/specparam/data/periodic.py
+++ b/specparam/data/periodic.py
@@ -81,7 +81,8 @@ def get_band_peak_group(group, band, threshold=None, thresh_param='PW', attribut
     you can do something like:
 
     >>> peaks = np.empty((0, 3))
-    >>> for res in group:  # doctest:+SKIP
+    >>> for i in range(len(fg.get_results())):  # doctest:+SKIP
+    ...     model = fg.get_model(i)
     ...     peaks = np.vstack((peaks, get_band_peak(res, band, select_highest=False)))
 
     Examples


### PR DESCRIPTION
Currently it gets `AttributeError: 'numpy.ndarray' object has no attribute 'peak_params_'` — that's because you pass res.peaks rather than the actual model.

As far as I understand, there is no straightforward way to get all models, you need to call get_model() on each index. Iterating over the `SpectralGroupModel` just gives you a bunch of `FitResults` and not models.  