### PR TITLE
[MNT] - Fix up docstring copying

### DIFF
--- a/specparam/models/event.py
+++ b/specparam/models/event.py
@@ -8,7 +8,7 @@ from specparam.results.utils import run_parallel_event, pbar
 from specparam.data.data import Data3D
 from specparam.data.conversions import event_group_to_dataframe, dict_to_df
 from specparam.data.utils import flatten_results_dict
-from specparam.modutils.docs import (copy_doc_func_to_method, docs_get_section,
+from specparam.modutils.docs import (copy_func_docstring_drop_first, docs_get_section,
                                      replace_docstring_sections)
 from specparam.reports.save import save_event_report
 from specparam.reports.strings import gen_event_results_str
@@ -205,20 +205,20 @@ class SpectralTimeEventModel(SpectralTimeModel):
             super().print(info, concise=concise)
 
 
-    @copy_doc_func_to_method(plot_event_model)
+    @copy_func_docstring_drop_first(plot_event_model)
     def plot(self, save_fig=False, file_name=None, file_path=None, **plot_kwargs):
 
         plot_event_model(self, save_fig=save_fig, file_name=file_name,
                          file_path=file_path, **plot_kwargs)
 
 
-    @copy_doc_func_to_method(save_event_report)
+    @copy_func_docstring_drop_first(save_event_report)
     def save_report(self, file_name, file_path=None, add_settings=True):
 
         save_event_report(self, file_name, file_path, add_settings)
 
 
-    @copy_doc_func_to_method(save_event)
+    @copy_func_docstring_drop_first(save_event)
     def save(self, file_name, file_path=None, append=False,
              save_results=False, save_settings=False, save_data=False):
 

--- a/specparam/models/group.py
+++ b/specparam/models/group.py
@@ -17,8 +17,8 @@ from specparam.io.models import save_group
 from specparam.io.files import load_jsonlines
 from specparam.reports.save import save_group_report
 from specparam.reports.strings import gen_group_results_str
-from specparam.modutils.docs import (copy_func_docstring_drop_first, docs_get_section,
-                                     replace_docstring_sections)
+from specparam.modutils.docs import (copy_func_docstring, copy_func_docstring_drop_first,
+                                     docs_get_section, replace_docstring_sections)
 from specparam.utils.checks import check_inds
 
 ###################################################################################################
@@ -243,13 +243,13 @@ class SpectralGroupModel(SpectralModel):
         self._reset_data_results(clear_spectrum=True, clear_results=True)
 
 
-    @copy_doc_func_to_method(Results2D.get_params)
+    @copy_func_docstring(Results2D.get_params)
     def get_params(self, component, field=None):
 
         return self.results.get_params(component, field)
 
 
-    @copy_doc_func_to_method(Results2D.get_metrics)
+    @copy_func_docstring(Results2D.get_metrics)
     def get_metrics(self, category, measure=None):
 
         return self.results.get_metrics(category, measure)

--- a/specparam/models/group.py
+++ b/specparam/models/group.py
@@ -17,8 +17,8 @@ from specparam.io.models import save_group
 from specparam.io.files import load_jsonlines
 from specparam.reports.save import save_group_report
 from specparam.reports.strings import gen_group_results_str
-from specparam.modutils.docs import (copy_doc_func_to_method,
-                                     docs_get_section, replace_docstring_sections)
+from specparam.modutils.docs import (copy_func_docstring_drop_first, docs_get_section,
+                                     replace_docstring_sections)
 from specparam.utils.checks import check_inds
 
 ###################################################################################################
@@ -186,13 +186,13 @@ class SpectralGroupModel(SpectralModel):
         self.print('results')
 
 
-    @copy_doc_func_to_method(plot_group_model)
+    @copy_func_docstring_drop_first(plot_group_model)
     def plot(self, **plot_kwargs):
 
         plot_group_model(self, **plot_kwargs)
 
 
-    @copy_doc_func_to_method(save_group)
+    @copy_func_docstring_drop_first(save_group)
     def save(self, file_name, file_path=None, append=False,
              save_results=False, save_settings=False, save_data=False):
 
@@ -326,7 +326,7 @@ class SpectralGroupModel(SpectralModel):
         return group
 
 
-    @copy_doc_func_to_method(save_group_report)
+    @copy_func_docstring_drop_first(save_group_report)
     def save_report(self, file_name, file_path=None, add_settings=True):
 
         save_group_report(self, file_name, file_path, add_settings)

--- a/specparam/models/model.py
+++ b/specparam/models/model.py
@@ -21,8 +21,8 @@ from specparam.algorithms.definitions import ALGORITHMS, check_algorithm_definit
 from specparam.reports.save import save_model_report
 from specparam.reports.strings import gen_model_results_str
 from specparam.modutils.errors import NoDataError, FitError
-from specparam.modutils.docs import (copy_doc_func_to_method, replace_docstring_sections,
-                                     docs_get_section)
+from specparam.modutils.docs import (copy_func_docstring_drop_first, docs_get_section,
+                                     replace_docstring_sections)
 from specparam.utils.checks import check_all_none
 from specparam.io.files import load_json
 from specparam.io.models import save_model
@@ -234,7 +234,7 @@ class SpectralModel(BaseModel):
             super().print(info, concise=concise)
 
 
-    @copy_doc_func_to_method(plot_model)
+    @copy_func_docstring_drop_first(plot_model)
     def plot(self, plot_peaks=None, plot_aperiodic=True, freqs=None, power_spectrum=None,
              freq_range=None, plt_log=False, add_legend=True, ax=None, data_kwargs=None,
              model_kwargs=None, aperiodic_kwargs=None, peak_kwargs=None, **plot_kwargs):
@@ -245,7 +245,7 @@ class SpectralModel(BaseModel):
                    aperiodic_kwargs=aperiodic_kwargs, peak_kwargs=peak_kwargs, **plot_kwargs)
 
 
-    @copy_doc_func_to_method(save_model)
+    @copy_func_docstring_drop_first(save_model)
     def save(self, file_name, file_path=None, append=False,
              save_results=False, save_settings=False, save_data=False):
 
@@ -298,7 +298,7 @@ class SpectralModel(BaseModel):
         return self.results.get_metrics(category, measure)
 
 
-    @copy_doc_func_to_method(save_model_report)
+    @copy_func_docstring_drop_first(save_model_report)
     def save_report(self, file_name, file_path=None, add_settings=True, **plot_kwargs):
 
         save_model_report(self, file_name, file_path, add_settings, **plot_kwargs)

--- a/specparam/models/model.py
+++ b/specparam/models/model.py
@@ -21,8 +21,8 @@ from specparam.algorithms.definitions import ALGORITHMS, check_algorithm_definit
 from specparam.reports.save import save_model_report
 from specparam.reports.strings import gen_model_results_str
 from specparam.modutils.errors import NoDataError, FitError
-from specparam.modutils.docs import (copy_func_docstring_drop_first, docs_get_section,
-                                     replace_docstring_sections)
+from specparam.modutils.docs import (copy_func_docstring, copy_func_docstring_drop_first,
+                                     docs_get_section, replace_docstring_sections)
 from specparam.utils.checks import check_all_none
 from specparam.io.files import load_json
 from specparam.io.models import save_model
@@ -286,13 +286,13 @@ class SpectralModel(BaseModel):
                 self.results._regenerate_model(self.data.freqs)
 
 
-    @copy_doc_func_to_method(Results.get_params)
+    @copy_func_docstring(Results.get_params)
     def get_params(self, component, field=None):
 
         return self.results.get_params(component, field)
 
 
-    @copy_doc_func_to_method(Results.get_metrics)
+    @copy_func_docstring(Results.get_metrics)
     def get_metrics(self, category, measure=None):
 
         return self.results.get_metrics(category, measure)

--- a/specparam/models/time.py
+++ b/specparam/models/time.py
@@ -9,7 +9,7 @@ from specparam.io.models import save_time
 from specparam.plts.time import plot_time_model
 from specparam.reports.save import save_time_report
 from specparam.reports.strings import gen_time_results_str
-from specparam.modutils.docs import (copy_doc_func_to_method, docs_get_section,
+from specparam.modutils.docs import (copy_func_docstring_drop_first, docs_get_section,
                                      replace_docstring_sections)
 from specparam.utils.checks import check_inds
 
@@ -157,7 +157,7 @@ class SpectralTimeModel(SpectralGroupModel):
             super().print(info, concise=concise)
 
 
-    @copy_doc_func_to_method(plot_time_model)
+    @copy_func_docstring_drop_first(plot_time_model)
     def plot(self, plot_type='time', save_fig=False, file_name=None, file_path=None, **plot_kwargs):
 
         if plot_type == 'time':
@@ -167,14 +167,14 @@ class SpectralTimeModel(SpectralGroupModel):
             super().plot(save_fig=save_fig, file_name=file_name, file_path=file_path, **plot_kwargs)
 
 
-    @copy_doc_func_to_method(save_time)
+    @copy_func_docstring_drop_first(save_time)
     def save(self, file_name, file_path=None, append=False,
              save_results=False, save_settings=False, save_data=False):
 
         save_time(self, file_name, file_path, append, save_results, save_settings, save_data)
 
 
-    @copy_doc_func_to_method(save_time_report)
+    @copy_func_docstring_drop_first(save_time_report)
     def save_report(self, file_name, file_path=None, add_settings=True):
 
         save_time_report(self, file_name, file_path, add_settings)

--- a/specparam/modutils/docs.py
+++ b/specparam/modutils/docs.py
@@ -224,8 +224,31 @@ def docs_add_section(docstring, section):
     return new_docstring
 
 
-def copy_doc_func_to_method(source):
-    """Decorator that copies method docstring from function, dropping first parameter.
+def copy_func_docstring(source):
+    """Decorator that copies docstring from source.
+
+    Parameters
+    ----------
+    source : function
+        Source function to copy docstring from.
+
+    Returns
+    -------
+    wrapper : function
+        The decorated function, with updated docs.
+    """
+
+    def wrapper(func):
+
+        func.__doc__ = deepcopy(source.__doc__)
+
+        return func
+
+    return wrapper
+
+
+def copy_func_docstring_drop_first(source):
+    """Decorator that copies docstring from source, dropping first parameter.
 
     Parameters
     ----------

--- a/specparam/results/results.py
+++ b/specparam/results/results.py
@@ -12,7 +12,7 @@ from specparam.results.components import ModelComponents
 from specparam.metrics.metrics import Metrics
 from specparam.utils.checks import check_inds
 from specparam.modutils.errors import NoModelError
-from specparam.modutils.docs import (copy_doc_func_to_method, docs_get_section,
+from specparam.modutils.docs import (copy_func_docstring, docs_get_section,
                                      replace_docstring_sections)
 from specparam.data.stores import FitResults
 from specparam.data.conversions import group_to_dict, event_group_to_dict
@@ -210,7 +210,7 @@ class Results():
         return getattr(self.params, component).get_params(version, field)
 
 
-    @copy_doc_func_to_method(Metrics.get_metrics)
+    @copy_func_docstring(Metrics.get_metrics)
     def get_metrics(self, category, measure=None):
 
         return self.metrics.get_metrics(category, measure)
@@ -419,7 +419,7 @@ class Results2D(Results):
         return get_group_params(self.group_results, self.modes, component, field)
 
 
-    @copy_doc_func_to_method(Metrics.get_metrics)
+    @copy_func_docstring(Metrics.get_metrics)
     def get_metrics(self, category, measure=None):
 
         return get_group_metrics(self.group_results, category, measure)

--- a/specparam/tests/modutils/test_docs.py
+++ b/specparam/tests/modutils/test_docs.py
@@ -85,7 +85,7 @@ def test_copy_func_docstring(tdocstring):
     def tfunc(): pass
     tfunc.__doc__ = tdocstring
 
-    @copy_doc_func_to_method(tfunc)
+    @copy_func_docstring(tfunc)
     def tfunc_out():
         pass
 
@@ -101,7 +101,7 @@ def test_copy_func_docstring_drop_first(tdocstring):
 
     class tobj():
 
-        @copy_doc_func_to_method(tfunc)
+        @copy_func_docstring_drop_first(tfunc)
         def tmethod():
             pass
 

--- a/specparam/tests/modutils/test_docs.py
+++ b/specparam/tests/modutils/test_docs.py
@@ -80,7 +80,21 @@ def test_docs_add_section(tdocstring):
     assert '%' not in new_docstring
     assert 'new note' in new_docstring
 
-def test_copy_doc_func_to_method(tdocstring):
+def test_copy_func_docstring(tdocstring):
+
+    def tfunc(): pass
+    tfunc.__doc__ = tdocstring
+
+    @copy_doc_func_to_method(tfunc)
+    def tfunc_out():
+        pass
+
+    assert tfunc_out.__doc__
+
+    for el in ['first', 'second']:
+        assert el in tfunc_out.__doc__
+
+def test_copy_func_docstring_drop_first(tdocstring):
 
     def tfunc(): pass
     tfunc.__doc__ = tdocstring
@@ -94,7 +108,6 @@ def test_copy_doc_func_to_method(tdocstring):
     assert tobj.tmethod.__doc__
     assert 'first' not in tobj.tmethod.__doc__
     assert 'second' in tobj.tmethod.__doc__
-
 
 def test_copy_doc_class(tdocstring):
 


### PR DESCRIPTION
This PR fixes what used to be called the `copy_doc_func_to_method` decorator function, splitting it into two different decorator functions with separate use cases for dropping or not the first parameter. 