### PR TITLE
[MNT] - Update handling of default colors

### DIFF
--- a/specparam/plts/aperiodic.py
+++ b/specparam/plts/aperiodic.py
@@ -7,7 +7,7 @@ import numpy as np
 from specparam.sim.gen import gen_freqs
 from specparam.modutils.dependencies import safe_import, check_dependency
 from specparam.modes.modes import check_mode_definition
-from specparam.plts.settings import ITERABLES, PLT_FIGSIZES
+from specparam.plts.settings import ITERABLES, PLT_FIGSIZES, DEFAULT_COLORS
 from specparam.plts.templates import plot_yshade
 from specparam.plts.style import style_param_plot, style_plot
 from specparam.plts.utils import check_ax, recursive_plot, savefig, check_plot_kwargs
@@ -105,7 +105,7 @@ def plot_aperiodic_fits(aps, freq_range, aperiodic_mode, control_offset=False, a
     if isinstance(aps, list):
 
         if not colors:
-            colors = cycle(plt.rcParams['axes.prop_cycle'].by_key()['color'])
+            colors = cycle(DEFAULT_COLORS)
 
         recursive_plot(aps, plot_function=plot_aperiodic_fits, ax=ax,
                        freq_range=tuple(freq_range), aperiodic_mode=aperiodic_mode,

--- a/specparam/plts/periodic.py
+++ b/specparam/plts/periodic.py
@@ -7,7 +7,7 @@ import numpy as np
 from specparam.sim import gen_freqs
 from specparam.modutils.dependencies import safe_import, check_dependency
 from specparam.modes.modes import check_mode_definition
-from specparam.plts.settings import ITERABLES, PLT_FIGSIZES
+from specparam.plts.settings import ITERABLES, PLT_FIGSIZES, DEFAULT_COLORS
 from specparam.plts.templates import plot_yshade
 from specparam.plts.style import style_param_plot, style_plot
 from specparam.plts.utils import check_ax, recursive_plot, savefig, check_plot_kwargs
@@ -109,7 +109,7 @@ def plot_peak_fits(peaks, periodic_mode, freq_range=None, average='mean', shade=
     if isinstance(peaks, list):
 
         if not colors:
-            colors = cycle(plt.rcParams['axes.prop_cycle'].by_key()['color'])
+            colors = cycle(DEFAULT_COLORS)
 
         recursive_plot(peaks, plot_function=plot_peak_fits, ax=ax,
                        periodic_mode=periodic_mode,

--- a/specparam/plts/settings.py
+++ b/specparam/plts/settings.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 
 import numpy as np
+from matplotlib.colors import to_hex
 
 from specparam.modutils.dependencies import safe_import
 
@@ -14,8 +15,10 @@ plt = safe_import('.pyplot', 'matplotlib')
 # Define list of iterables to check against
 ITERABLES = (list, tuple, np.ndarray)
 
-# Define list of default plot colors
-DEFAULT_COLORS = plt.rcParams['axes.prop_cycle'].by_key()['color'] if plt else None
+# Define list of default plot colors, making sure colors are hex, for downstream consistency
+#   Hex encoding changed in mpl: https://github.com/matplotlib/matplotlib/issues/29915
+DEFAULT_COLORS = [to_hex(col) for col in plt.rcParams['axes.prop_cycle'].by_key()['color']] \
+    if plt else None
 
 # Define default figure sizes
 PLT_FIGSIZES = {


### PR DESCRIPTION
This updates handling of getting default colors from matplotlib - as the behaviour there changed (returning ([rgba], ...) instead of hex, which led to downstream errors on our side (see: https://github.com/matplotlib/matplotlib/issues/29915). 

This explicitly casts accessed default color cycle to hex to maintain consistency on our side. 